### PR TITLE
DOC-3853: Update/add support_url attribute

### DIFF
--- a/playbooks/site-local-astra-cli.yaml
+++ b/playbooks/site-local-astra-cli.yaml
@@ -112,7 +112,7 @@ asciidoc:
     gtable1: 'book'
     gtable2: 'reader'
 
-    support_url: 'https://houston.datastax.com/hc/requests/new'
+    support_url: 'https://support.datastax.com'
     astra_docs_base_url: 'https://docs.datastax.com/en/astra/docs'
 
     # The "glossary-url" attribute below is used by writers when linking to a

--- a/playbooks/site-publish-astra-cli.yaml
+++ b/playbooks/site-publish-astra-cli.yaml
@@ -115,7 +115,7 @@ asciidoc:
     gtable1: 'book'
     gtable2: 'reader'
 
-    support_url: 'https://houston.datastax.com/hc/requests/new'
+    support_url: 'https://support.datastax.com'
     astra_docs_base_url: 'https://docs.datastax.com/en/astra/docs'
 
     # The "glossary-url" attribute below is used by writers when linking to a


### PR DESCRIPTION
**JIRA:** https://datastax.jira.com/browse/DOC-3853

This change updates/adds the `support_url` attribute with the correct link to the DataStax Support website.