### PR TITLE
DOC-5707, DOC-5708 improve attributes for DITA

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -24,7 +24,6 @@ asciidoc:
     astra-ui-link: '{astra-url}[{astra-ui}^]'
     scb: 'Secure Connect Bundle (SCB)'
     scb-short: 'SCB'
-    scb-brief: 'Secure Connect Bundle'
     dsbulk: 'DataStax Bulk Loader (DSBulk)'
     dsbulk-short: 'DSBulk'
     cql: 'Cassandra Query Language (CQL)'

--- a/antora.yml
+++ b/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     product-repo: 'https://github.com/datastax/astra-cli'
     db-serverless: 'Serverless (non-vector)'
     db-serverless-vector: 'Serverless (vector)'
-    db-classic: 'Managed Clusters'
+    db-classic: 'Astra Managed Clusters'
     devops-api: 'DevOps API'
     astra-stream: 'Astra Streaming'
     astra-ui: 'Astra Portal'

--- a/antora.yml
+++ b/antora.yml
@@ -16,7 +16,7 @@ asciidoc:
     product-repo: 'https://github.com/datastax/astra-cli'
     db-serverless: 'Serverless (non-vector)'
     db-serverless-vector: 'Serverless (vector)'
-    db-classic: 'Managed Cluster'
+    db-classic: 'Managed Clusters'
     devops-api: 'DevOps API'
     astra-stream: 'Astra Streaming'
     astra-ui: 'Astra Portal'

--- a/in-progress/managing.adoc
+++ b/in-progress/managing.adoc
@@ -14,7 +14,7 @@ You can use `**DATABASE_NAME**` instead of `**DATABASE_ID**` in all `astra db` c
 == Create a database
 
 The {product} can create {db-serverless} and {db-serverless-vector} databases with on-demand (non-PCU) capacity only.
-It cannot create {product-short} {db-classic} (Classic) databases; however, you can use the {product} to <<get-database-details,get information>> about your existing {db-classic} databases.
+It cannot deploy {product-short} {db-classic} (Classic databases); however, you can use the {product} to <<get-database-details,get information>> about your existing {db-classic} deployments.
 
 If your organization requires that new databases to belong to a xref:astra-db-serverless:administration:provisioned-capacity-units.adoc[PCU group], you must xref:astra-db-serverless:databases:create-database.adoc[use the {astra-ui} or {devops-api} to create databases] because the {product} doesn't support PCU group assignment with database creation.
 
@@ -1936,7 +1936,7 @@ Use the `astra db list-regions-vector` command to get a list of available cloud 
 astra db list-regions-vector
 ----
 
-Use the `astra db list-regions-classic` command to get a list of available cloud provider regions that support {product-short} {db-classic} (Classic) databases:
+Use the `astra db list-regions-classic` command to get a list of available cloud provider regions that support {product-short} {db-classic} deployments:
 
 [source,bash]
 ----
@@ -2059,7 +2059,7 @@ OPTIONS
 
 [TIP]
 ====
-`classic` refers to {product-short} {db-classic} databases, which were previously known as {astra-db} Classic databases.
+`classic` refers to {product-short} {db-classic}, which was previously known as {astra-db} Classic.
 ====
 
 .Expand to see all `db list-regions-classic` options

--- a/in-progress/managing.adoc
+++ b/in-progress/managing.adoc
@@ -14,7 +14,7 @@ You can use `**DATABASE_NAME**` instead of `**DATABASE_ID**` in all `astra db` c
 == Create a database
 
 The {product} can create {db-serverless} and {db-serverless-vector} databases with on-demand (non-PCU) capacity only.
-It cannot deploy {product-short} {db-classic} (Classic databases); however, you can use the {product} to <<get-database-details,get information>> about your existing {db-classic} databases.
+It cannot deploy {db-classic} (Classic) databases; however, you can use the {product} to <<get-database-details,get information>> about your existing {db-classic} databases.
 
 If your organization requires that new databases to belong to a xref:astra-db-serverless:administration:provisioned-capacity-units.adoc[PCU group], you must xref:astra-db-serverless:databases:create-database.adoc[use the {astra-ui} or {devops-api} to create databases] because the {product} doesn't support PCU group assignment with database creation.
 
@@ -1936,7 +1936,7 @@ Use the `astra db list-regions-vector` command to get a list of available cloud 
 astra db list-regions-vector
 ----
 
-Use the `astra db list-regions-classic` command to get a list of available cloud provider regions that support {product-short} {db-classic}:
+Use the `astra db list-regions-classic` command to get a list of available cloud provider regions that support {db-classic} (Classic) databases:
 
 [source,bash]
 ----
@@ -2059,7 +2059,7 @@ OPTIONS
 
 [TIP]
 ====
-`classic` refers to {product-short} {db-classic}, which was previously known as {astra-db} Classic.
+`classic` refers to {db-classic}, which was previously known as {astra-db} Classic.
 ====
 
 .Expand to see all `db list-regions-classic` options

--- a/in-progress/managing.adoc
+++ b/in-progress/managing.adoc
@@ -14,7 +14,7 @@ You can use `**DATABASE_NAME**` instead of `**DATABASE_ID**` in all `astra db` c
 == Create a database
 
 The {product} can create {db-serverless} and {db-serverless-vector} databases with on-demand (non-PCU) capacity only.
-It cannot deploy {product-short} {db-classic} (Classic databases); however, you can use the {product} to <<get-database-details,get information>> about your existing {db-classic} deployments.
+It cannot deploy {product-short} {db-classic} (Classic databases); however, you can use the {product} to <<get-database-details,get information>> about your existing {db-classic} databases.
 
 If your organization requires that new databases to belong to a xref:astra-db-serverless:administration:provisioned-capacity-units.adoc[PCU group], you must xref:astra-db-serverless:databases:create-database.adoc[use the {astra-ui} or {devops-api} to create databases] because the {product} doesn't support PCU group assignment with database creation.
 
@@ -1936,7 +1936,7 @@ Use the `astra db list-regions-vector` command to get a list of available cloud 
 astra db list-regions-vector
 ----
 
-Use the `astra db list-regions-classic` command to get a list of available cloud provider regions that support {product-short} {db-classic} deployments:
+Use the `astra db list-regions-classic` command to get a list of available cloud provider regions that support {product-short} {db-classic}:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/manage-cli.adoc
+++ b/modules/ROOT/pages/manage-cli.adoc
@@ -559,7 +559,7 @@ The {product} home folder contains the following items:
 
 * The `astra` executable (scripted installations only)
 * Accessory executables that are downloaded by certain commands, such as `xref:commands:astra-db-cqlsh.adoc[]` and `xref:commands:astra-db-dsbulk.adoc[]`
-* xref:astra-db-serverless:databases:secure-connect-bundle.adoc[{scb-brief}s]
+* A xref:astra-db-serverless:databases:secure-connect-bundle.adoc[{scb}] for each database that you've connected to with the {product}.
 * Cache files for <<command-auto-completion,command auto-completion>>
 * Logs
 


### PR DESCRIPTION
* Change db-classic attribute to follow product name. See https://github.com/riptano/astra-vector-docs/pull/1405 for full explanation.
* Change one instance of {scb-brief} to {scb}, and then remove {scb-brief} from antora.yml. This attribute should only be used for UI labels, otherwise use either {scb} or {scb-short}.
* Rephrase one line to avoid a pluralized attribute.