### PR TITLE
DOC-5730 remove tabs and collapsibles from manually written content

### DIFF
--- a/in-progress/administration.adoc
+++ b/in-progress/administration.adoc
@@ -13,8 +13,6 @@ astra org
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +----------------+-----------------------------------------+
@@ -24,13 +22,10 @@ astra org
 | id             | 2dbd3c55-6a68-4b5b-9155-5be9d41823e8    |
 +----------------+-----------------------------------------+
 ----
-====
 
 === `org` options
 
-.Expand to see all `org` options
-[%collapsible]
-====
+.All org options
 [source,console]
 ----
 NAME
@@ -45,7 +40,6 @@ SYNOPSIS
         Where * indicates the default command(s)
         See 'astra help org <command>' for more information on a specific command.
 ----
-====
 
 == List users
 
@@ -57,8 +51,6 @@ astra user list
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +--------------------------------------+--------------------+---------+
@@ -69,13 +61,10 @@ astra user list
 | 20e0a061-c9d2-42a5-9d00-352f3b2adedc | taylor@example.com | invited |
 +--------------------------------------+--------------------+---------+
 ----
-====
 
 === `user list` options
 
-.Expand to see all `user list` options
-[%collapsible]
-====
+.All user list options
 [source,console]
 ----
 NAME
@@ -109,7 +98,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 == Add a user
 
@@ -121,13 +109,10 @@ astra user invite **USER_EMAIL**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Database Administrator
 ----
-====
 
 [IMPORTANT]
 ====
@@ -136,9 +121,7 @@ If you don't specify a role when inviting a user, the user is automatically assi
 
 === `user invite` options
 
-.Expand to see all `user invite` options
-[%collapsible]
-====
+.All user invite options
 [source,console]
 ----
 NAME
@@ -184,7 +167,6 @@ OPTIONS
         <EMAIL>
             User Email
 ----
-====
 
 Use the `-r`/`--role` option to specify a role when inviting a user:
 
@@ -208,13 +190,10 @@ astra user invite alice@example.com -r "Organization Administrator"
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Organization Administrator
 ----
-====
 
 == Get user details
 
@@ -233,8 +212,6 @@ astra user describe **USER**
 Replace `**USER**` with the email address or ID of the user you want to get information about.
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +----------------+-----------------------------------------+
@@ -248,13 +225,10 @@ Replace `**USER**` with the email address or ID of the user you want to get info
 |                |                                         |
 +----------------+-----------------------------------------+
 ----
-====
 
 === `user get` options
 
-.Expand to see all `user get` options
-[%collapsible]
-====
+.All user get options
 [source,console]
 ----
 NAME
@@ -296,13 +270,10 @@ OPTIONS
         <EMAIL>
             User Email
 ----
-====
 
 === `user describe` options
 
-.Expand to see all `user describe` options
-[%collapsible]
-====
+.All user describe options
 [source,console]
 ----
 NAME
@@ -344,7 +315,6 @@ OPTIONS
         <EMAIL>
             User Email
 ----
-====
 
 == Remove a user
 
@@ -368,19 +338,14 @@ astra user delete **USER**
 Replace `**USER**` with the email address or ID of the user you want to delete.
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Deleting user 'alice@example.com' (async operation)
 ----
-====
 
 === `user delete` options
 
-.Expand to see all `user delete` options
-[%collapsible]
-====
+.All user delete options
 [source,console]
 ----
 NAME
@@ -422,7 +387,6 @@ OPTIONS
         <EMAIL>
             User email or identifier
 ----
-====
 
 [#list-roles]
 == List roles
@@ -435,8 +399,6 @@ astra role list
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +--------------------------------------+----------------------------+----------------------------+
@@ -461,13 +423,10 @@ astra role list
 | c3cdd2a6-29d5-43b9-b929-8d878066d1c4 | My Custom Role             | My Custom Role             |
 +--------------------------------------+----------------------------+----------------------------+
 ----
-====
 
 === `role list` options
 
-.Expand to see all `role list` options
-[%collapsible]
-====
+.All role list options
 [source,console]
 ----
 NAME
@@ -501,7 +460,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 == Get role details
 
@@ -520,8 +478,6 @@ astra role describe "**ROLE**"
 Replace `**ROLE**` with the name or ID of the role you want to get information about.
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +----------------+--------------------------------------------------------+
@@ -579,13 +535,10 @@ Replace `**ROLE**` with the name or ID of the role you want to get information a
 |                |                                                        |
 +----------------+--------------------------------------------------------+
 ----
-====
 
 === `role get` options
 
-.Expand to see all `role get` options
-[%collapsible]
-====
+.All role get options
 [source,console]
 ----
 NAME
@@ -627,13 +580,10 @@ OPTIONS
         <ROLE>
             Role name or identifier
 ----
-====
 
 === `role describe` options
 
-.Expand to see all `role describe` options
-[%collapsible]
-====
+.All role describe options
 [source,console]
 ----
 NAME
@@ -675,7 +625,6 @@ OPTIONS
         <ROLE>
             Role name or identifier
 ----
-====
 
 [#list-tokens]
 == Get a list of tokens
@@ -690,20 +639,15 @@ astra token list
 ////
 // TODO: The command is not working as expected. Must investigate and figure out why it is reporting the following error: [ERROR] NOT_FOUND: Role '...' has not been found.
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 
 ----
-====
 ////
 
 === `token list` options
 
-.Expand to see all `token list` options
-[%collapsible]
-====
+.All token list options
 [source,console]
 ----
 NAME
@@ -737,7 +681,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 == Create an application token
 
@@ -751,8 +694,6 @@ astra token create -r "**ROLE**"
 Replace `**ROLE**` with the name or ID of the role you want to assign to the token.
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    A new token has been created.
@@ -764,13 +705,10 @@ Replace `**ROLE**` with the name or ID of the role you want to assign to the tok
 | Token          | AstraCS:FZm...                                                                                                                   |
 +----------------+----------------------------------------------------------------------------------------------------------------------------------+
 ----
-====
 
 === `token create` options
 
-.Expand to see all `token create` options
-[%collapsible]
-====
+.All token create options
 [source,console]
 ----
 NAME
@@ -808,7 +746,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 == Show the current token
 
@@ -820,19 +757,14 @@ astra token get
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 AstraCS:FZm...
 ----
-====
 
 === `token get` options
 
-.Expand to see all `token get` options
-[%collapsible]
-====
+.All token get options
 [source,console]
 ----
 NAME
@@ -866,7 +798,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 == Delete an application token
 
@@ -891,19 +822,14 @@ Replace `**CLIENT_ID**` with the client ID of the token that you want to delete.
 To get a token's client ID, see <<list-tokens>>.
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Your token has been deleted.
 ----
-====
 
 === `token delete` options
 
-.Expand to see all `token delete` options
-[%collapsible]
-====
+.All token delete options
 [source,console]
 ----
 NAME
@@ -945,13 +871,10 @@ OPTIONS
         <TOKEN>
             token identifier
 ----
-====
 
 === `token revoke` options
 
-.Expand to see all `token revoke` options
-[%collapsible]
-====
+.All token revoke options
 [source,console]
 ----
 NAME
@@ -993,4 +916,3 @@ OPTIONS
         <TOKEN>
             token identifier
 ----
-====

--- a/in-progress/astra-streaming-cli.adoc
+++ b/in-progress/astra-streaming-cli.adoc
@@ -13,14 +13,11 @@ astra streaming create **TENANT_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://api.astra.datastax.com/v2/streaming/tenants/my-streaming-tenant
 [OK]    Tenant 'my-streaming-tenant' has being created.
 ----
-====
 
 Running `astra streaming create` without any options deploys the tenant in the default cloud provider (`aws`), region (`useast2`), plan (`free`) and namespace (`default`).
 
@@ -45,14 +42,12 @@ astra streaming create **TENANT_NAME** --if-not-exist
 ====
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://api.astra.datastax.com/v2/streaming/tenants/my-streaming-tenant
 [OK]    Tenant already existed (--if-not-exist)
 ----
-====
+
 
 Alternatively, you can use the `astra streaming exist` command to check ahead of time if a tenant name is already in use:
 
@@ -62,20 +57,15 @@ astra streaming exist my-streaming-tenant
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://api.astra.datastax.com/v2/streaming/tenants/my-streaming-tenant
 [OK]    Tenant 'my-streaming-tenant' exists.
 ----
-====
 
 === `streaming create` options
 
-.Expand to see all `streaming create` options
-[%collapsible]
-====
+.All streaming create options
 [source,console]
 ----
 NAME
@@ -140,7 +130,6 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 You can use the `-c`, `-r`, and `-p`  options to define the cloud provider, region, and plan when creating a tenant:
 
@@ -153,20 +142,15 @@ astra streaming create **TENANT_NAME** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://api.astra.datastax.com/v2/streaming/tenants/my-streaming-tenant
 [OK]    Tenant 'my-streaming-tenant' has being created.
 ----
-====
 
 === `streaming exist` options
 
-.Expand to see all `streaming exist` options
-[%collapsible]
-====
+.All streaming exist options
 [source,console]
 ----
 NAME
@@ -208,7 +192,6 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 == Get tenant details
 
@@ -220,8 +203,6 @@ astra streaming list
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +---------------------+-----------+----------------+----------------+
@@ -230,7 +211,6 @@ astra streaming list
 | my-streaming-tenant | aws       | useast1        | active         |
 +---------------------+-----------+----------------+----------------+
 ----
-====
 
 Use the `astra streaming get` or `astra streaming describe` command to get information about a specific tenant:
 
@@ -245,8 +225,6 @@ astra streaming describe **TENANT_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +------------------+-------------------------------------------------------------+
@@ -265,7 +243,6 @@ astra streaming describe **TENANT_NAME**
 | WebSocketUrl     | wss://pulsar-aws-useast1.streaming.datastax.com:8001/ws/v2  |
 +------------------+-------------------------------------------------------------+
 ----
-====
 
 Use the `astra streaming status` command to get the status of a specific tenant:
 
@@ -275,13 +252,10 @@ astra streaming status **TENANT_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Tenant 'my-streaming-tenant' has status 'active'
 ----
-====
 
 Use the `astra streaming pulsar-token` command to get the {pulsar-short} token for a specific tenant:
 
@@ -291,19 +265,14 @@ astra streaming pulsar-token **TENANT_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MzYyMTcxMzAsImlzcyI6ImRhdGFzdGF4Iiwic3ViIjoiY2xpZW50OzJkYmQzYzU1LTZhNjgtNGI1Yi05MTU1LTViZTlkNDE4MjNkODtiWGt0YzNSeVpXRnRhVzVuTFhSbGJtRnVkQT09OzVlMzQ5Y2NlNzgiLCJ0b2tlbmlkIjoiNWUzNDljY2U3OCJ9.aVQiSD7wS21ltrVn-Beei39WC9T9oGGz2P95DjXbHsqB-Lgp2N_T2jTjBxzoKv5-AoCGjMZAK7vr0SvKsyzViXY9ubE72hu0TsnPPFyDcqX-3fpdI0HoA62ppXrqmZvZVKw2bCCg4868xhfGJvY_S5R8K6Zz-2bOuKf8I271V7-gUVw5zlbnkmCER6ch-11Kq3o4HMa9rgoY1W0DNv4V6CNQdjM4qs6qLal0U9Qd3jEKR935jsr518LEye8F4rMGhqNX-Wrnb45kiejrVA4nAdLK6mBMhIZ68lw2J3bQqjCX26NXPsJFmQiR1I0YLFgRJXpoFhYjmA058duTP9Hy4Q
 ----
-====
 
 === `streaming list` options
 
-.Expand to see all `streaming list` options
-[%collapsible]
-====
+.All streaming list options
 [source,console]
 ----
 NAME
@@ -337,13 +306,10 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 === `streaming get` options
 
-.Expand to see all `streaming get` options
-[%collapsible]
-====
+.All streaming get options
 [source,console]
 ----
 NAME
@@ -390,13 +356,10 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 === `streaming describe` options
 
-.Expand to see all `streaming describe` options
-[%collapsible]
-====
+.All streaming describe options
 [source,console]
 ----
 NAME
@@ -443,13 +406,10 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 === `streaming status` options
 
-.Expand to see all `streaming status` options
-[%collapsible]
-====
+.All streaming status options
 [source,console]
 ----
 NAME
@@ -491,13 +451,10 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 === `streaming pulsar-token` options
 
-.Expand to see all `streaming pulsar-token` options
-[%collapsible]
-====
+.All streaming pulsar-token options
 [source,console]
 ----
 NAME
@@ -539,7 +496,6 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 == Get a list of available {astra-stream} regions
 
@@ -551,8 +507,6 @@ astra streaming list-regions
 ----
 
 .Result
-[%collapsible]
-====
 The result is a table with `Cloud Provider`, `Region`, and `Full Name` columns.
 `Full Name` can be empty or contain the region's name and location (city, state, or country).
 
@@ -564,13 +518,10 @@ The result is a table with `Cloud Provider`, `Region`, and `Full Name` columns.
 | **PROVIDER**    | **REGION**          | **NAME**                      |
 +-----------------+---------------------+-------------------------------+
 ----
-====
 
 === `streaming list-regions` options
 
-.Expand to see all `streaming list-regions` options
-[%collapsible]
-====
+.All streaming list-regions options
 [source,console]
 ----
 NAME
@@ -613,13 +564,10 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 === `streaming list-clouds` options
 
-.Expand to see all `streaming list-clouds` options
-[%collapsible]
-====
+.All streaming list-clouds options
 [source,console]
 ----
 NAME
@@ -653,8 +601,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
-
 
 == Delete a tenant
 
@@ -666,19 +612,14 @@ astra streaming delete **TENANT_NAME**
 ----
 
 .Result
-[%collapsible]
-====
-[source,console,subs="+quotes"]
+[source,console]
 ----
 [OK]    Deleting Tenant 'my-streaming-tenant'
 ----
-====
 
 === `streaming delete` options
 
-.Expand to see all `streaming delete` options
-[%collapsible]
-====
+.All streaming delete options
 [source,console]
 ----
 NAME
@@ -720,7 +661,6 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 == Use the {pulsar-short} shell
 
@@ -737,8 +677,6 @@ astra streaming pulsar-shell **TENANT_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Downloading PulsarShell, please wait...
@@ -754,7 +692,6 @@ Type exit or quit to end the shell session.
 
 default(pulsar-aws-useast2.streaming.datastax.com)>
 ----
-====
 
 Type `exit` and press kbd:[Enter] to exit the {pulsar-short} shell.
 
@@ -762,9 +699,7 @@ The first time you use the `astra streaming pulsar-shell` commands, the {product
 
 === `streaming pulsar-shell` options
 
-.Expand to see all `streaming pulsar-shell` options
-[%collapsible]
-====
+.All streaming pulsar-shell options
 [source,console]
 ----
 NAME
@@ -823,7 +758,6 @@ OPTIONS
         <TENANT>
             Tenant unique name
 ----
-====
 
 Use the `-e`/`--execute` option to execute a {pulsar-short} shell command:
 
@@ -855,14 +789,11 @@ astra streaming create my-streaming-tenant
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://api.astra.datastax.com/v2/streaming/tenants/my-streaming-tenant
 [OK]    Tenant 'my-streaming-tenant' has being created.
 ----
-====
 
 . In two separate terminals, run the following command to start the {pulsar-short} shell in each terminal:
 +
@@ -872,8 +803,6 @@ astra streaming pulsar-shell my-streaming-tenant
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Pulsar-shell is starting please wait for connection establishment...
@@ -885,7 +814,6 @@ Welcome to Pulsar shell!
 Type help to get started or try the autocompletion (TAB button).
 Type exit or quit to end the shell session.
 ----
-====
 
 . In the first terminal, create a topic named `demo` in the `default` namespace:
 +
@@ -903,13 +831,10 @@ admin topics list my-streaming-tenant/default
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 persistent://my-streaming-tenant/default/demo
 ----
-====
 // TODO: Confirm the output of the command.
 
 . Start a consumer on the `demo` topic:
@@ -920,8 +845,6 @@ client consume persistent://my-streaming-tenant/default/demo -s astra_cli_tuto -
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 .. init ...
@@ -930,7 +853,6 @@ client consume persistent://my-streaming-tenant/default/demo -s astra_cli_tuto -
 2022-09-12T12:28:35,460+0200 [pulsar-client-io-1-1] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://my-streaming-tenant/default/demo/default/demo][astra_cli_tuto] Subscribing to topic on cnx [id: 0xc5ce3ec4, L:/192.168.82.1:53683 - R:pulsar-aws-useast2.streaming.datastax.com/3.16.119.226:6651], consumerId 0
 2022-09-12T12:28:35,645+0200 [pulsar-client-io-1-1] INFO  org.apache.pulsar.client.impl.ConsumerImpl - [persistent://my-streaming-tenant/default/demo/default/demo][astra_cli_tuto] Subscribed to topic on pulsar-aws-useast2.streaming.datastax.com/3.16.119.226:6651 -- consumer: 0
 ----
-====
 // TODO: Confirm the output of the command.
 
 . In the second terminal, start a producer.
@@ -941,8 +863,6 @@ client produce persistent://my-streaming-tenant/default/demo/default/demo -m "he
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 2022-09-12T12:36:28,684+0200 [pulsar-client-io-14-1] INFO  org.apache.pulsar.client.impl.ClientCnx - [id: 0x682890b5, L:/192.168.1.106:53796 ! R:pulsar-aws-useast2.streaming.datastax.com/3.138.177.230:6651] Disconnected
@@ -954,7 +874,6 @@ key:[null], properties:[], content:world
 ----- got message -----
 key:[null], properties:[], content:hello
 ----
-====
 // TODO: Confirm the output of the command.
 
 == Change Data Capture (CDC)
@@ -971,8 +890,6 @@ astra streaming list-cdc **TENANT_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +--------------------+----------------+----------------+-------------------+----------------+----------------+
@@ -981,13 +898,10 @@ astra streaming list-cdc **TENANT_NAME**
 | pulsar-aws-useast1 | astracdc       | cdc_demo_db    | cdc_demo_keyspace | cdc_demo_table | running        |
 +--------------------+----------------+----------------+-------------------+----------------+----------------+
 ----
-====
 
 === `streaming list-cdc` options
 
-.Expand to see all `streaming list-cdc` options
-[%collapsible]
-====
+.All streaming list-cdc options
 [source,console]
 ----
 NAME
@@ -1029,7 +943,6 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 == Create environment variables
 
@@ -1049,10 +962,7 @@ By default, the {product} saves the `.env` file to the directory where you run t
 
 If a `.env` file already exists in the directory, the {product} appends the new environment variables to the existing file.
 
-.Result
-[%collapsible%open]
-====
-..env
+.Result (.env)
 [source,console]
 ----
 ASTRA_STREAMING_BROKER_URL="pulsar+ssl://pulsar-aws-useast2.streaming.datastax.com:6651"
@@ -1063,7 +973,6 @@ ASTRA_STREAMING_REGION="useast2"
 ASTRA_STREAMING_WEBSERVICE_URL="https://pulsar-aws-useast2.api.streaming.datastax.com"
 ASTRA_STREAMING_WEBSOCKET_URL="wss://pulsar-aws-useast2.streaming.datastax.com:8001/ws/v2"
 ----
-====
 
 [WARNING]
 ====
@@ -1077,9 +986,7 @@ The {scb} contains sensitive information that establishes a connection to your d
 The directory must already exist before you run the `streaming create-dotenv` command.
 If the directory doesn't exist, the command fails with the error `INVALID_ARGUMENT: Destination folder has not been found`.
 
-.Expand to see all `streaming create-dotenv` options
-[%collapsible]
-====
+.All streaming create-dotenv options
 [source,console]
 ----
 NAME
@@ -1126,7 +1033,6 @@ OPTIONS
         <TENANT>
             Tenant identifier
 ----
-====
 
 Use the `-d`/`--directory` option to save the `.env` file to a specified directory:
 
@@ -1136,10 +1042,7 @@ astra streaming create-dotenv **TENANT_NAME** -d ~/tmp
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    File '/Users/USERNAME/tmp/.env' has been created/amended
 ----
-====

--- a/in-progress/change-data-capture.adoc
+++ b/in-progress/change-data-capture.adoc
@@ -15,13 +15,10 @@ astra db create cdc_demo_db -r us-east1 -k cdc_demo_keyspace
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Database 'cdc_demo_db' has been created with id 'ce5e563c-3248-4064-b03c-5892433a1347'. It is now active after waiting 422 seconds.
 ----
-====
 
 == Create a streaming tenant
 
@@ -33,14 +30,11 @@ astra streaming create cdc-demo-tenant -c gcp -r useast1
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://api.astra.datastax.com/v2/streaming/tenants/cdc-demo-tenant
 [OK]    Tenant 'cdc-demo-tenant' has being created.
 ----
-====
 
 == Create a table in your database
 
@@ -56,13 +50,10 @@ astra db cqlsh exec cdc_demo_db \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
 ----
-====
 
 Confirm table creation:
 +
@@ -73,8 +64,6 @@ astra db cqlsh exec cdc_demo_db \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -84,7 +73,6 @@ astra db cqlsh exec cdc_demo_db \
 
 (0 rows)
 ----
-====
 
 == Create a CDC connection
 
@@ -101,13 +89,10 @@ astra db create-cdc cdc_demo_db \
 ////
 // TODO: The command is not working as expected. Must investigate and figure out why it is reporting the following error: [ERROR] INVALID_ARGUMENT: Error Code=422(422) Invalid information provided to create DB: 422 Unprocessable Entity: databaseId, keyspace, tableName, and orgId are mandatory fields
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 
 ----
-====
 ////
 
 Use `xref:commands:astra-db-list-cdcs.adoc[]` to confirm CDC details for the database and tenant:
@@ -118,8 +103,6 @@ astra db list-cdcs cdc_demo_db
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +-----------------------+-------------------+----------------+----------------+--------------------+----------------+----------------+
@@ -128,7 +111,6 @@ astra db list-cdcs cdc_demo_db
 | 57a3024f-cdcdemotable | cdc_demo_keyspace | cdc_demo_table | cdc-demo-tenant| pulsar-aws-useast1 | astracdc       | Running        |
 +-----------------------+-------------------+----------------+----------------+--------------------+----------------+----------------+
 ----
-====
 
 [source,shell]
 ----
@@ -136,8 +118,6 @@ astra streaming list-cdc cdc-demo-tenant
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +--------------------+----------------+----------------+-------------------+----------------+----------------+
@@ -146,7 +126,6 @@ astra streaming list-cdc cdc-demo-tenant
 | pulsar-aws-useast1 | astracdc       | cdc_demo_db    | cdc_demo_keyspace | cdc_demo_table | running        |
 +--------------------+----------------+----------------+-------------------+----------------+----------------+
 ----
-====
 
 == Connect a sink
 

--- a/in-progress/dsbulk.adoc
+++ b/in-progress/dsbulk.adoc
@@ -23,8 +23,6 @@ astra db dsbulk load **DB_ID** -k **KEYSPACE_NAME** -t **TABLE_NAME** --url **FI
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Downloading Dsbulk, please wait...
@@ -44,10 +42,9 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/LOAD_20250123-020734-995267/checkpoint.csv
 ----
-====
 
 [TIP]
-======
+====
 You can use the `xref:commands:astra-db-cqlsh-exec.adoc[]` command to check that the data imported successfully:
 
 [source,shell,subs="+quotes"]
@@ -56,8 +53,6 @@ astra db cqlsh exec **DB_ID** "SELECT * FROM **KEYSPACE_NAME**.**TABLE_NAME** LI
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -88,7 +83,6 @@ astra db cqlsh exec **DB_ID** "SELECT * FROM **KEYSPACE_NAME**.**TABLE_NAME** LI
 (20 rows)
 ----
 ====
-======
 
 == Unload data
 
@@ -100,8 +94,6 @@ astra db dsbulk unload **DB_ID** -k **KEYSPACE_NAME** -t **TABLE_NAME** --url **
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk unload -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO -delim , -url unloaded_data -header true -encoding UTF-8 -skipRecords 0 -maxErrors 100
@@ -116,7 +108,6 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/UNLOAD_20250123-021231-557959/checkpoint.csv
 ----
-====
 
 == Count data
 
@@ -128,8 +119,6 @@ astra db dsbulk count **DB_ID** -k **KEYSPACE_NAME** -t **TABLE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk count -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO
@@ -145,7 +134,6 @@ To resume the current operation, re-run it with the same settings, and add the f
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/COUNT_20250123-021120-127216/checkpoint.csv
 134574
 ----
-====
 
 == Complete {dsbulk-short} example
 
@@ -159,13 +147,10 @@ astra db create dsbulk_demo_db -r us-east1 -k dsbulk_demo_keyspace
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Database 'dsbulk_demo_db' has been created with id '8b8fea68-404e-4f12-9a79-02079060adfa'. It is now active after waiting 433 seconds.
 ----
-====
 
 . Download the xref:ROOT:attachment$cities.csv[cities.csv] file and move it to the directory where you run {product} commands.
 +
@@ -190,8 +175,6 @@ astra db cqlsh start dsbulk_demo_db -k dsbulk_demo_keyspace
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Connected to cndb at 127.0.0.1:9042.
@@ -199,7 +182,6 @@ Connected to cndb at 127.0.0.1:9042.
 Use HELP for help.
 token@cqlsh:dsbulk_demo_keyspace>
 ----
-====
 +
 .. Copy and paste the following CQL statement into the `cqlsh` prompt and press kbd:[Enter]:
 +
@@ -233,8 +215,6 @@ astra db dsbulk load dsbulk_demo_db -k dsbulk_demo_keyspace -t cities_by_country
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk load -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO -delim , -url cities.csv -header true -encoding UTF-8 -skipRecords 0 -maxErrors 100
@@ -252,7 +232,6 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/LOAD_20250123-020734-995267/checkpoint.csv
 ----
-====
 
 . Confirm that the data loaded successfully:
 +
@@ -262,8 +241,6 @@ astra db cqlsh exec dsbulk_demo_db "select * from dsbulk_demo_keyspace.cities_by
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -293,7 +270,6 @@ astra db cqlsh exec dsbulk_demo_db "select * from dsbulk_demo_keyspace.cities_by
 
 (20 rows)
 ----
-====
 
 . Count the loaded data:
 +
@@ -303,8 +279,6 @@ astra db dsbulk count dsbulk_demo_db -k dsbulk_demo_keyspace -t cities_by_countr
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk count -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO
@@ -320,7 +294,6 @@ To resume the current operation, re-run it with the same settings, and add the f
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/COUNT_20250123-021120-127216/checkpoint.csv
 134574
 ----
-====
 
 . Unload the data into CSV files:
 +
@@ -330,8 +303,6 @@ astra db dsbulk unload dsbulk_demo_db -k dsbulk_demo_keyspace -t cities_by_count
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk unload -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO -delim , -url unloaded_data -header true -encoding UTF-8 -skipRecords 0 -maxErrors 100
@@ -346,6 +317,5 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/UNLOAD_20250123-021231-557959/checkpoint.csv
 ----
-====
 +
 This command unloads row data from the `cities_by_country` table, and stores it as CSV files within a subsirectory names `unloaded_data` in the same directory where you ran the command.

--- a/in-progress/managing.adoc
+++ b/in-progress/managing.adoc
@@ -414,19 +414,22 @@ OPTIONS
 
 xref:astra-db-serverless:databases:manage-collections.adoc[Collections] store semi-structured data, in the form of documents, in {db-serverless-vector} databases.
 
+=== Create a collection
+
+[IMPORTANT]
+====
 When you create a collection, you decide if the collection can store structured vector data.
 This is known as a _vector-enabled collection_.
 For vector-enabled collections, you also decide how to provide embeddings.
 You can bring your own embeddings and xref:astra-db-serverless:databases:embedding-generation.adoc[automatically generate embeddings with vectorize].
 **You must decide which options you need when you create the collection.**
+====
 
-Use the `astra db create-collection` command to create a new collection in a {db-serverless-vector} database:
+Use the `astra db create-collection` command to create a new collection in a {db-serverless-vector} database.
+The options to use depend on your desired collection settings.
 
-[tabs]
-======
-Bring my own embeddings::
-+
---
+==== Bring my own embeddings
+
 Use these options if you plan to generate your own embeddings and import them when you load data into your collection:
 
 [source,bash,subs="+quotes"]
@@ -444,8 +447,7 @@ Replace the following:
 * (Optional) `**SIMILARITY_METRIC**`: The xref:astra-db-serverless:get-started:concepts.adoc#metrics[similarity metric] that your embedding model will use to compare vectors.
 The available metrics are `cosine` (default), `dot_product`, and `euclidean`.
 
-Example:
-
+.Example
 [source,bash]
 ----
 astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
@@ -460,11 +462,9 @@ astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
---
 
-Use an {product-short}-hosted provider::
-+
---
+==== Use an {product-short}-hosted provider
+
 To automatically generate embeddings with xref:astra-db-serverless:databases:embedding-generation.adoc[{product-short} vectorize], add an embedding provider integration to your collection.
 Embedding provider integrations are either {product-short}-hosted or external.
 
@@ -490,8 +490,7 @@ You can only set the dimensions if the chosen model supports a range of dimensio
 * (Optional) `**SIMILARITY_METRIC**`: The xref:astra-db-serverless:get-started:concepts.adoc#metrics[similarity metric] that your embedding model will use to compare vectors.
 The available metrics are `cosine` (default), `dot_product`, and `euclidean`.
 
-Example:
-
+.Example
 [source,bash]
 ----
 astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
@@ -508,11 +507,9 @@ astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
---
 
-Use an external provider::
-+
---
+==== Use an external provider
+
 To automatically generate embeddings with xref:astra-db-serverless:databases:embedding-generation.adoc[{product-short} vectorize], add an embedding provider integration to your collection.
 Embedding provider integrations are either {product-short}-hosted or external.
 
@@ -540,8 +537,7 @@ You can only set the dimensions if the chosen model supports a range of dimensio
 * (Optional) `**SIMILARITY_METRIC**`: The xref:astra-db-serverless:get-started:concepts.adoc#metrics[similarity metric] that your embedding model will use to compare vectors.
 The available metrics are `cosine` (default), `dot_product`, and `euclidean`.
 
-Example:
-
+.Example
 [source,bash]
 ----
 astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
@@ -559,11 +555,9 @@ astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
---
 
-Non-vector collection::
-+
---
+==== Non-vector collection
+
 To create a collection that is _not_ vector-enabled, omit the `-d` and `-m` options.
 Be aware that non-vector collections don't support vector-dependent functionality like vector search.
 
@@ -578,80 +572,8 @@ astra db create-collection **DATABASE_ID** -c **COLLECTION_NAME**
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
---
-======
 
-Use the `astra db list-collections` command to get a list of the collections in `default_keyspace`:
-
-[source,bash,subs="+quotes"]
-----
-astra db list-collections **DATABASE_ID**
-----
-
-.Result
-[source,console]
-----
-+---------------------+-----------+-------------------+--------------------+--------------+------------------------+
-| Name                | DefaultId | Vector Dimension  | Similarity Metric  | AI Provider  | AI Model               |
-+---------------------+-----------+-------------------+--------------------+--------------+------------------------+
-| my_collection       | default   | 1024              | dot_product        |              |                        |
-| my_collection2      | default   | 1024              | dot_product        | nvidia       | NV-Embed-QA            |
-| my_collection3      | default   | 1024              | dot_product        | openai       | text-embedding-3-small |
-+---------------------+-----------+-------------------+--------------------+--------------+------------------------+
-----
-
-Use the `astra db describe-collection` command to get information about a specific collection:
-
-[source,bash,subs="+quotes"]
-----
-astra db describe-collection **DATABASE_ID** -c **COLLECTION_NAME**
-----
-
-.Result
-[source,console]
-----
-+-------------------+-----------------------------------------+
-| Attribute         | Value                                   |
-+-------------------+-----------------------------------------+
-| Name              | my_collection                           |
-| Estim. Count      | 0                                       |
-|                   |                                         |
-| Vector:           |                                         |
-| Vector Dimension  | 1024                                    |
-| Similarity Metric | dot_product                             |
-+-------------------+-----------------------------------------+
-
-[OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
-----
-
-Use the `astra db truncate-collection` command to clear an existing collection:
-
-[source,bash,subs="+quotes"]
-----
-astra db truncate-collection **DATABASE_ID** -c **COLLECTION_NAME**
-----
-
-.Result
-[source,console]
-----
-[OK]    Collection 'my_collection' as been truncated from '58747660-464b-4085-bef2-c3f3e5401e3d'.
-----
-
-Use the `astra db delete-collection` command to delete a collection:
-
-[source,bash,subs="+quotes"]
-----
-astra db delete-collection **DATABASE_ID** -c **COLLECTION_NAME**
-----
-
-.Result
-[source,console]
-----
-[OK]    Collection 'my_collection' as been deleted from '58747660-464b-4085-bef2-c3f3e5401e3d'.
-[OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
-----
-
-=== `db create-collection` options
+==== `db create-collection` options
 
 .All db create-collection options
 [source,console]
@@ -756,7 +678,28 @@ astra db create-collection **DATABASE_ID** \
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
 
-=== `db list-collections` options
+=== Get all collections
+
+Use the `astra db list-collections` command to get a list of the collections in `default_keyspace`:
+
+[source,bash,subs="+quotes"]
+----
+astra db list-collections **DATABASE_ID**
+----
+
+.Result
+[source,console]
+----
++---------------------+-----------+-------------------+--------------------+--------------+------------------------+
+| Name                | DefaultId | Vector Dimension  | Similarity Metric  | AI Provider  | AI Model               |
++---------------------+-----------+-------------------+--------------------+--------------+------------------------+
+| my_collection       | default   | 1024              | dot_product        |              |                        |
+| my_collection2      | default   | 1024              | dot_product        | nvidia       | NV-Embed-QA            |
+| my_collection3      | default   | 1024              | dot_product        | openai       | text-embedding-3-small |
++---------------------+-----------+-------------------+--------------------+--------------+------------------------+
+----
+
+==== `db list-collections` options
 
 .All db list-collections options
 [source,console]
@@ -824,7 +767,33 @@ astra db list-collections **DATABASE_ID** -k **KEYSPACE_NAME**
 +--------------------------+-----------+-------------------+--------------------+--------------+---------------------+
 ----
 
-=== `db describe-collection` options
+=== Get one collection
+
+Use the `astra db describe-collection` command to get information about a specific collection:
+
+[source,bash,subs="+quotes"]
+----
+astra db describe-collection **DATABASE_ID** -c **COLLECTION_NAME**
+----
+
+.Result
+[source,console]
+----
++-------------------+-----------------------------------------+
+| Attribute         | Value                                   |
++-------------------+-----------------------------------------+
+| Name              | my_collection                           |
+| Estim. Count      | 0                                       |
+|                   |                                         |
+| Vector:           |                                         |
+| Vector Dimension  | 1024                                    |
+| Similarity Metric | dot_product                             |
++-------------------+-----------------------------------------+
+
+[OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
+----
+
+==== `db describe-collection` options
 
 .All db describe-collection options
 [source,console]
@@ -903,7 +872,22 @@ astra db describe-collection **DATABASE_ID** \
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
 
-=== `db truncate-collection` options
+=== Empty a collection
+
+Use the `astra db truncate-collection` command to clear an existing collection (delete all documents from the specified collection):
+
+[source,bash,subs="+quotes"]
+----
+astra db truncate-collection **DATABASE_ID** -c **COLLECTION_NAME**
+----
+
+.Result
+[source,console]
+----
+[OK]    Collection 'my_collection' as been truncated from '58747660-464b-4085-bef2-c3f3e5401e3d'.
+----
+
+==== `db truncate-collection` options
 
 .All db truncate-collection options
 [source,console]
@@ -971,7 +955,23 @@ astra db truncate-collection **DATABASE_ID** \
 [OK]    Collection 'my_collection' as been truncated from '58747660-464b-4085-bef2-c3f3e5401e3d'.
 ----
 
-=== `db delete-collection` options
+=== Delete a collection
+
+Use the `astra db delete-collection` command to delete a collection:
+
+[source,bash,subs="+quotes"]
+----
+astra db delete-collection **DATABASE_ID** -c **COLLECTION_NAME**
+----
+
+.Result
+[source,console]
+----
+[OK]    Collection 'my_collection' as been deleted from '58747660-464b-4085-bef2-c3f3e5401e3d'.
+[OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
+----
+
+==== `db delete-collection` options
 
 .All db delete-collection options
 [source,console]
@@ -3540,7 +3540,7 @@ OPTIONS
 [source,console]
 ----
 NAME
-        astra db list-cdc - List CDC available on this databse
+        astra db list-cdc - List CDC available on this database
 
 SYNOPSIS
         astra db list-cdc [ {-cf | --config-file} <CONFIG_FILE> ]

--- a/in-progress/managing.adoc
+++ b/in-progress/managing.adoc
@@ -26,8 +26,6 @@ astra db create **DATABASE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Database 'my_serverless_db' does not exist. Creating database 'my_serverless_db' with keyspace 'default_keyspace'
@@ -36,7 +34,6 @@ astra db create **DATABASE_NAME**
 [INFO]  Database 'my_serverless_db' has status 'ACTIVE' (took 470346 millis)
 [OK]    Database 'my_serverless_db' is ready.
 ----
-====
 
 Use the `--vector` option to create a {db-serverless-vector} database:
 
@@ -46,8 +43,6 @@ astra db create **DATABASE_NAME** --vector
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Database 'my_vector_db' does not exist. Creating database 'my_vector_db' with keyspace 'default_keyspace'
@@ -57,7 +52,6 @@ astra db create **DATABASE_NAME** --vector
 [INFO]  Database 'my_vector_db' has status 'ACTIVE' (took 142712 millis)
 [OK]    Database 'my_vector_db' is ready.
 ----
-====
 
 Running `astra db create` without any options deploys the database in an available *Free* region and uses `default_keyspace` as the name for the default keyspace.
 
@@ -67,9 +61,7 @@ include::ROOT:partial$async-option-active.adoc[]
 
 === `db create` options
 
-.Expand to see all `db create` options
-[%collapsible]
-====
+.All db create options
 [source,console]
 ----
 NAME
@@ -144,7 +136,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-c`, `-r`, and `-k` options to specify the cloud provider, region, and keyspace name when creating a database:
 
@@ -157,8 +148,6 @@ astra db create **DATABASE_NAME** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Database 'my_serverless_db' does not exist. Creating database 'my_serverless_db' with keyspace 'my_keyspace'
@@ -167,7 +156,6 @@ astra db create **DATABASE_NAME** \
 [INFO]  Database 'my_serverless_db' has status 'ACTIVE' (took 109050 millis)
 [OK]    Database 'my_serverless_db' is ready.
 ----
-====
 
 //TODO: Confirm that this no longer applies.
 ////
@@ -194,8 +182,6 @@ astra db create-keyspace **DATABASE_ID** -k **KEYSPACE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Keyspace  'keyspace2' is creating.
@@ -204,7 +190,6 @@ astra db create-keyspace **DATABASE_ID** -k **KEYSPACE_NAME**
 [OK]    Database '26054aa9-eb37-4d88-b343-7c934cd1d7bc' is ready.
 [OK]    Database '26054aa9-eb37-4d88-b343-7c934cd1d7bc' is ready.
 ----
-====
 
 The database enters *Maintenance* status while creating the keyspace.
 When the database returns to *Active* status, you can use the new keyspace.
@@ -212,7 +197,7 @@ When the database returns to *Active* status, you can use the new keyspace.
 include::ROOT:partial$async-option-active.adoc[]
 
 [TIP]
-======
+====
 By default, the {product} returns an error if a keyspace with the same name already exists.
 However, if you use the `--if-not-exist` option, the {product} automatically connects to the existing keyspace instead of returning an error.
 This option can be useful when invoking the {product} in idempotent scripts.
@@ -223,8 +208,6 @@ astra db create-keyspace **DATABASE_ID** -k **KEYSPACE_NAME** --if-not-exist
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Keyspace  'keyspace1' already exists. Connecting to keyspace.
@@ -232,7 +215,6 @@ astra db create-keyspace **DATABASE_ID** -k **KEYSPACE_NAME** --if-not-exist
 [OK]    Database '26054aa9-eb37-4d88-b343-7c934cd1d7bc' is ready.
 ----
 ====
-======
 
 Use the `astra db list-keyspaces` command to get a list of the keyspaces in a database:
 
@@ -242,8 +224,6 @@ astra db list-keyspaces **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +---------------------+
@@ -253,7 +233,6 @@ astra db list-keyspaces **DATABASE_ID**
 | keyspace2           |
 +---------------------+
 ----
-====
 
 Use the `astra db delete-keyspace` command to delete a keyspace from a database:
 
@@ -263,15 +242,12 @@ astra db delete-keyspace **DATABASE_ID** -k **KEYSPACE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Database '26054aa9-eb37-4d88-b343-7c934cd1d7bc' has status 'MAINTENANCE' waiting to be 'ACTIVE' ...
 [INFO]  Database 'my_serverless_db' has status 'ACTIVE' (took 6804 millis)
 [OK]    Database '26054aa9-eb37-4d88-b343-7c934cd1d7bc' is ready.
 ----
-====
 
 [WARNING]
 ====
@@ -286,9 +262,7 @@ If you delete the default keyspace, {astra-db} automatically selects another key
 
 === `db create-keyspace` options
 
-.Expand to see all `db create-keyspace` options
-[%collapsible]
-====
+.All db create-keyspace options
 [source,console]
 ----
 NAME
@@ -340,13 +314,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db list-keyspaces` options
 
-.Expand to see all `db list-keyspaces` options
-[%collapsible]
-====
+.All db list-keyspaces options
 [source,console]
 ----
 NAME
@@ -388,13 +359,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db delete-keyspace` options
 
-.Expand to see all `db delete-keyspace` options
-[%collapsible]
-====
+.All db delete-keyspace options
 [source,console]
 ----
 NAME
@@ -440,7 +408,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 [#manage-collections]
 == Manage collections
@@ -488,14 +455,11 @@ astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 --
 
 Use an {product-short}-hosted provider::
@@ -539,14 +503,11 @@ astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 --
 
 Use an external provider::
@@ -593,14 +554,11 @@ astra db create-collection 58747660-464b-4085-bef2-c3f3e5401e3d \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 --
 
 Non-vector collection::
@@ -615,14 +573,11 @@ astra db create-collection **DATABASE_ID** -c **COLLECTION_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'default_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 --
 ======
 
@@ -634,8 +589,6 @@ astra db list-collections **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +---------------------+-----------+-------------------+--------------------+--------------+------------------------+
@@ -646,7 +599,6 @@ astra db list-collections **DATABASE_ID**
 | my_collection3      | default   | 1024              | dot_product        | openai       | text-embedding-3-small |
 +---------------------+-----------+-------------------+--------------------+--------------+------------------------+
 ----
-====
 
 Use the `astra db describe-collection` command to get information about a specific collection:
 
@@ -656,8 +608,6 @@ astra db describe-collection **DATABASE_ID** -c **COLLECTION_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +-------------------+-----------------------------------------+
@@ -673,7 +623,6 @@ astra db describe-collection **DATABASE_ID** -c **COLLECTION_NAME**
 
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 
 Use the `astra db truncate-collection` command to clear an existing collection:
 
@@ -683,13 +632,10 @@ astra db truncate-collection **DATABASE_ID** -c **COLLECTION_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been truncated from '58747660-464b-4085-bef2-c3f3e5401e3d'.
 ----
-====
 
 Use the `astra db delete-collection` command to delete a collection:
 
@@ -699,20 +645,15 @@ astra db delete-collection **DATABASE_ID** -c **COLLECTION_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been deleted from '58747660-464b-4085-bef2-c3f3e5401e3d'.
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 
 === `db create-collection` options
 
-.Expand to see all `db create-collection` options
-[%collapsible]
-====
+.All db create-collection options
 [source,console]
 ----
 NAME
@@ -797,7 +738,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-k` / `--keyspace` option to create a collection in a specific keyspace:
 
@@ -810,20 +750,15 @@ astra db create-collection **DATABASE_ID** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been created from db '58747660-464b-4085-bef2-c3f3e5401e3d' on keyspace  'my_keyspace'
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 
 === `db list-collections` options
 
-.Expand to see all `db list-collections` options
-[%collapsible]
-====
+.All db list-collections options
 [source,console]
 ----
 NAME
@@ -870,7 +805,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-k` / `--keyspace` option to get a list of the collections in a specific keyspace:
 
@@ -880,8 +814,6 @@ astra db list-collections **DATABASE_ID** -k **KEYSPACE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +--------------------------+-----------+-------------------+--------------------+--------------+---------------------+
@@ -891,13 +823,10 @@ astra db list-collections **DATABASE_ID** -k **KEYSPACE_NAME**
 | my_collection_non_vector | default   |                   |                    |              |                     |
 +--------------------------+-----------+-------------------+--------------------+--------------+---------------------+
 ----
-====
 
 === `db describe-collection` options
 
-.Expand to see all `db describe-collection` options
-[%collapsible]
-====
+.All db describe-collection options
 [source,console]
 ----
 NAME
@@ -947,7 +876,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-k` / `--keyspace` option to get information about a collection in a specific keyspace:
 
@@ -959,8 +887,6 @@ astra db describe-collection **DATABASE_ID** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +-------------------+-----------------------------------------+
@@ -976,13 +902,10 @@ astra db describe-collection **DATABASE_ID** \
 
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 
 === `db truncate-collection` options
 
-.Expand to see all `db truncate-collection` options
-[%collapsible]
-====
+.All db truncate-collection options
 [source,console]
 ----
 NAME
@@ -1032,7 +955,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-k` / `--keyspace` option to clear an existing collection in a specific keyspace:
 
@@ -1044,19 +966,14 @@ astra db truncate-collection **DATABASE_ID** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been truncated from '58747660-464b-4085-bef2-c3f3e5401e3d'.
 ----
-====
 
 === `db delete-collection` options
 
-.Expand to see all `db delete-collection` options
-[%collapsible]
-====
+.All db delete-collection options
 [source,console]
 ----
 NAME
@@ -1109,7 +1026,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-k` / `--keyspace` option to delete a collection from a specific keyspace:
 
@@ -1121,14 +1037,11 @@ astra db delete-collection **DATABASE_ID** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Collection 'my_collection' as been deleted from '58747660-464b-4085-bef2-c3f3e5401e3d'.
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 
 [#manage-tables]
 == Manage tables
@@ -1146,8 +1059,6 @@ astra db list-tables **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +---------------------+
@@ -1156,7 +1067,6 @@ astra db list-tables **DATABASE_ID**
 | students            |
 +---------------------+
 ----
-====
 
 Use the `astra db describe-table` command to get information about a specific table:
 
@@ -1166,8 +1076,6 @@ astra db describe-table **DATABASE_ID** -t **TABLE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +------------------+-----------------------------------------+
@@ -1189,7 +1097,6 @@ astra db describe-table **DATABASE_ID** -t **TABLE_NAME**
 | Partition Key    | [0] email                               |
 +------------------+-----------------------------------------+
 ----
-====
 
 Use the `astra db truncate-table` command to clear an existing table:
 
@@ -1199,13 +1106,10 @@ astra db truncate-table **DATABASE_ID** -t **TABLE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Table 'students' as been truncated from '58747660-464b-4085-bef2-c3f3e5401e3d'.
 ----
-====
 
 Use the `astra db delete-collection` command to delete a collection from a a {db-serverless-vector} database:
 
@@ -1215,20 +1119,15 @@ astra db delete-table **DATABASE_ID** -t **TABLE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Table 'students' as been deleted from '58747660-464b-4085-bef2-c3f3e5401e3d'.
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-====
 
 === `db list-tables` options
 
-.Expand to see all `db list-tables` options
-[%collapsible]
-====
+.All db list-tables options
 [source,console]
 ----
 NAME
@@ -1275,13 +1174,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db describe-table` options
 
-.Expand to see all `db describe-table` options
-[%collapsible]
-====
+.All db describe-table options
 [source,console]
 ----
 NAME
@@ -1330,13 +1226,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db truncate-table` options
 
-.Expand to see all `db truncate-table` options
-[%collapsible]
-====
+.All db truncate-table options
 [source,console]
 ----
 NAME
@@ -1385,13 +1278,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db delete-table` options
 
-.Expand to see all `db delete-table` options
-[%collapsible]
-====
+.All db delete-table options
 [source,console]
 ----
 NAME
@@ -1443,7 +1333,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 == Manage embedding providers
 
@@ -1454,12 +1343,10 @@ Use the `astra db list-embedding-providers` command to get a list of the embeddi
 astra db list-embedding-providers **DATABASE_ID**
 ----
 
-.Result
-[%collapsible]
-======
 The following result is for example purposes only.
 Supported embedding providers and options can change.
 
+.Result
 [source,console]
 ----
 +----------------------+--------------------------+--------+------------+---------+----------+
@@ -1478,7 +1365,6 @@ Supported embedding providers and options can change.
 | mistral              | Mistral AI               | 1      | 0          | ■       | ■        |
 +----------------------+--------------------------+--------+------------+---------+----------+
 ----
-======
 
 Use the `astra db describe-embedding-provider` command to get information about a specific embedding provider integration:
 
@@ -1489,12 +1375,10 @@ astra db describe-embedding-provider **DATABASE_ID** -ep **PROVIDER_NAME**
 
 The `**PROVIDER_NAME**` is the name listed in the `Key` column in the output of the `astra db list-embedding-providers` command.
 
-.Result
-[%collapsible]
-======
 The following result is for example purposes only.
 Supported embedding providers and options can change.
 
+.Result
 [source,console]
 ----
 +-------------------+---------------------------------------------------------------------------------------------+
@@ -1523,13 +1407,10 @@ Supported embedding providers and options can change.
 
 [OK]    Database '58747660-464b-4085-bef2-c3f3e5401e3d' is ready.
 ----
-======
 
 === `db list-embedding-providers` options
 
-.Expand to see all `db list-embedding-providers` options
-[%collapsible]
-====
+.All db list-embedding-providers options
 [source,console]
 ----
 NAME
@@ -1573,13 +1454,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db describe-embedding-provider` options
 
-.Expand to see all `db describe-embedding-provider` options
-[%collapsible]
-====
+.All db describe-embedding-provider options
 [source,console]
 ----
 NAME
@@ -1627,7 +1505,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 [#get-database-details]
 == Get database details
@@ -1640,8 +1517,6 @@ astra db list
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +---------------------+--------------------------------------+-----------+-------+---+-----------+
@@ -1651,7 +1526,6 @@ astra db list
 | my_vector_db        | 6fabb532-a3ac-4780-a1bc-d984531aed76 | us-east1  | gcp   | ■ | ACTIVE    |
 +---------------------+--------------------------------------+-----------+-------+---+-----------+
 ----
-====
 
 Use the `astra db get` or `astra db describe` command to get information about a specific database:
 
@@ -1666,8 +1540,6 @@ astra db describe **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +------------------+-----------------------------------------+
@@ -1685,7 +1557,6 @@ astra db describe **DATABASE_ID**
 | Regions          | [0] us-east1                            |
 +------------------+-----------------------------------------+
 ----
-====
 
 Use the `astra db status` command to get the status of a specific database:
 
@@ -1695,19 +1566,14 @@ astra db status **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    Database '96b1b6e3-5288-4cef-8a41-d4f1d36bbfca' has status 'ACTIVE'
 ----
-====
 
 === `db list` options
 
-.Expand to see all `db list` options
-[%collapsible]
-====
+.All db list options
 [source,console]
 ----
 NAME
@@ -1744,7 +1610,6 @@ OPTIONS
         --vector
             Create a database with vector search enabled
 ----
-====
 
 Use the `--vector` option to list only {db-serverless-vector} databases:
 
@@ -1754,8 +1619,6 @@ astra db list --vector
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +---------------------+--------------------------------------+-----------+-------+---+-----------+
@@ -1764,13 +1627,10 @@ astra db list --vector
 | my_vector_db        | ebae8d5a-4848-44c9-8485-87e413b60549 | us-east1  | gcp   | ■ | ACTIVE    |
 +---------------------+--------------------------------------+-----------+-------+---+-----------+
 ----
-====
 
 === `db get` options
 
-.Expand to see all ``db get` options
-[%collapsible]
-====
+.All db get options
 [source,console]
 ----
 NAME
@@ -1817,13 +1677,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db describe` options
 
-.Expand to see all `db describe` options
-[%collapsible]
-====
+.All db describe options
 [source,console]
 ----
 NAME
@@ -1870,13 +1727,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db status` options
 
-.Expand to see all `db status` options
-[%collapsible]
-====
+.All db status options
 [source,console]
 ----
 NAME
@@ -1918,7 +1772,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 == Get a list of available {astra-db} regions
 
@@ -1943,12 +1796,10 @@ Use the `astra db list-regions-classic` command to get a list of available cloud
 astra db list-regions-classic
 ----
 
-.Result
-[%collapsible]
-====
 The result for each `list-regions-*` command is a table with `Cloud Provider`, `Region`, and `Full Name` columns.
 `Full Name` can be empty or contain the region's name and location (city, state, or country).
 
+.Result
 [source,console,subs="+quotes"]
 ----
 +-----------------+---------------------+-------------------------------+
@@ -1957,13 +1808,10 @@ The result for each `list-regions-*` command is a table with `Cloud Provider`, `
 | **PROVIDER**    | **REGION**          | **NAME**                      |
 +-----------------+---------------------+-------------------------------+
 ----
-====
 
 === `db list-regions-serverless` options
 
-.Expand to see all `db list-regions-serverless` options
-[%collapsible]
-====
+.All db list-regions-serverless options
 [source,console]
 ----
 NAME
@@ -2005,13 +1853,10 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 === `db list-regions-vector` options
 
-.Expand to see all `db list-regions-vector` options
-[%collapsible]
-====
+.All db list-regions-vector options
 [source,console]
 ----
 NAME
@@ -2053,7 +1898,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 === `db list-regions-classic` options
 
@@ -2062,9 +1906,7 @@ OPTIONS
 `classic` refers to {db-classic}, which was previously known as {astra-db} Classic.
 ====
 
-.Expand to see all `db list-regions-classic` options
-[%collapsible]
-====
+.All db list-regions-classic options
 [source,console]
 ----
 NAME
@@ -2106,13 +1948,10 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 === `db list-clouds` options
 
-.Expand to see all `db list-clouds` options
-[%collapsible]
-====
+.All db list-clouds options
 [source,console]
 ----
 NAME
@@ -2146,7 +1985,6 @@ OPTIONS
         -v, --verbose
             Verbose mode with log in console
 ----
-====
 
 [#configure-multiple-regions]
 == Configure multiple regions
@@ -2168,13 +2006,10 @@ For more information, including requirements and costs for additional regions, s
 ////
 // TODO: The command is not working as expected. Must investigate and figure out why it is reporting the following error: [ERROR] UNAVAILABLE: Database 'my_serverless_db' has been found but operation cannot be processed due to invalid state (ACTIVE) expected (ACTIVE)
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 
 ----
-====
 ////
 
 Use the `astra db list-regions` command to list the regions where a database is deployed:
@@ -2185,8 +2020,6 @@ astra db list-regions **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +----------------+---------------------+----------------+----------------+
@@ -2196,7 +2029,6 @@ astra db list-regions **DATABASE_ID**
 | aws            | us-east-1 (default) | serverless     |                |
 +----------------+---------------------+----------------+----------------+
 ----
-====
 
 Use the `astra db delete-region` command to remove a region from a database:
 
@@ -2206,14 +2038,11 @@ astra db delete-region **DATABASE_ID** -r **REGION**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Region 'us-west1' is deleting.
 [OK]    Region us-west1 has been deleted
 ----
-====
 
 [IMPORTANT]
 ====
@@ -2225,9 +2054,7 @@ However, to avoid data loss, all data is replicated to the other regions before 
 
 === `db create-region` options
 
-.Expand to see all `db create-region` options
-[%collapsible]
-====
+.All db create-region options
 [source,console]
 ----
 NAME
@@ -2293,13 +2120,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db list-regions` options
 
-.Expand to see all `db list-regions` options
-[%collapsible]
-====
+.All db list-regions options
 [source,console]
 ----
 NAME
@@ -2341,13 +2165,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db delete-region` options
 
-.Expand to see all `db delete-region` options
-[%collapsible]
-====
+.All db delete-region options
 [source,console]
 ----
 NAME
@@ -2404,7 +2225,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 [#resume-database]
 == Resume a hibernated database
@@ -2422,9 +2242,7 @@ include::ROOT:partial$async-option-active.adoc[]
 
 === `db resume` options
 
-.Expand to see all `db resume` options
-[%collapsible]
-====
+.All db resume options
 [source,console]
 ----
 NAME
@@ -2476,7 +2294,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 == Terminate a database
 
@@ -2494,14 +2311,11 @@ astra db delete **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Deleting Database '26054aa9-eb37-4d88-b343-7c934cd1d7bc'
 [OK]    Database 26054aa9-eb37-4d88-b343-7c934cd1d7bc has been deleted
 ----
-====
 
 The database enters *Terminating* status while deletion occurs.
 
@@ -2510,9 +2324,7 @@ To run the command _asynchronously_, add the `--async` option.
 
 === `db delete` options
 
-.Expand to see all `db delete` options
-[%collapsible]
-====
+.All db delete options
 [source,console]
 ----
 NAME
@@ -2564,7 +2376,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 == Get database API endpoints
 
@@ -2576,13 +2387,10 @@ astra db get-endpoint-swagger **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://26054aa9-eb37-4d88-b343-7c934cd1d7bc-us-east-1.apps.astra.datastax.com/api/rest/swagger-ui/
 ----
-====
 
 Use the `get-endpoint-api` command to get the JSON API endpoint for a {db-serverless-vector} database:
 
@@ -2592,13 +2400,10 @@ astra db get-endpoint-api **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://26054aa9-eb37-4d88-b343-7c934cd1d7bc-us-east-1.apps.astra.datastax.com/api/rest
 ----
-====
 
 Use the `get-endpoint-playground` command to get the GraphQL playground endpoint for a non-vector database:
 
@@ -2608,19 +2413,14 @@ astra db get-endpoint-playground **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://26054aa9-eb37-4d88-b343-7c934cd1d7bc-us-east-1.apps.astra.datastax.com/api/playground
 ----
-====
 
 === `db get-endpoint-swagger` options
 
-.Expand to see all `db get-endpoint-swagger` options
-[%collapsible]
-====
+.All db get-endpoint-swagger options
 [source,console]
 ----
 NAME
@@ -2666,13 +2466,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db get-endpoint-api` options
 
-.Expand to see all `db get-endpoint-api` options
-[%collapsible]
-====
+.All db get-endpoint-api options
 [source,console]
 ----
 NAME
@@ -2718,13 +2515,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db get-endpoint-playground` options
 
-.Expand to see all `db get-endpoint-playground` options
-[%collapsible]
-====
+.All db get-endpoint-playground options
 [source,console]
 ----
 NAME
@@ -2771,7 +2565,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 [#cqlsh]
 == Use `cqlsh`
@@ -2792,8 +2585,6 @@ astra db cqlsh **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Downloading Cqlshell, please wait...
@@ -2804,7 +2595,6 @@ Connected to cndb at 127.0.0.1:9042.
 Use HELP for help.
 token@cqlsh>
 ----
-====
 
 Type `exit` or `quit;` and press kbd:[Enter] to exit `cqlsh`.
 
@@ -2812,7 +2602,7 @@ The first time you use the `astra db cqlsh` command, the {product} downloads and
 The {product} also downloads the {scb} for each database you connect to and stores the {scb-short} zip files in the `~/.astra/scb` directory.
 
 [TIP]
-======
+====
 If the {product} reports `ModuleNotFoundError`, check that you have a supported version of Python available in your terminal:
 
 [source,bash]
@@ -2821,20 +2611,15 @@ python -V
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Python 3.11.10
 ----
 ====
-======
 
 === `db cqlsh` options
 
-.Expand to see all `db cqlsh` options
-[%collapsible]
-====
+.All db cqlsh options
 [source,console]
 ----
 NAME
@@ -2905,7 +2690,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-k` / `--keyspace` option to connect directly to a specific keyspace:
 
@@ -2915,8 +2699,6 @@ astra db cqlsh **DATABASE_ID** -k **KEYSPACE_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -2925,7 +2707,6 @@ Connected to cndb at 127.0.0.1:9042.
 Use HELP for help.
 token@cqlsh:keyspace2>
 ----
-====
 
 Use the `-e` / `--execute` option to execute a CQL statement:
 
@@ -2935,8 +2716,6 @@ astra db cqlsh **DATABASE_ID** -e "describe keyspaces;"
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -2945,7 +2724,6 @@ system_auth    data_endpoint_auth  system_traces
 datastax_sla   default_keyspace    system_virtual_schema
 system_schema  system              system_views
 ----
-====
 
 Use the `-f` / `--file` option to execute a CQL file:
 
@@ -2954,10 +2732,7 @@ Use the `-f` / `--file` option to execute a CQL file:
 astra db cqlsh **DATABASE_ID** -f sample.cql
 ----
 
-.Example CQL file
-[%collapsible]
-====
-.sample.cql
+.sample.cql (Example CQL file)
 [source,cql]
 ----
 -- Use a specific keyspace
@@ -2977,11 +2752,8 @@ INSERT INTO users (id, name, email) VALUES (uuid(), 'Bob', 'bob@example.com');
 -- Query the data
 SELECT * FROM users;
 ----
-====
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -2993,10 +2765,9 @@ SELECT * FROM users;
 
 (2 rows)
 ----
-====
 
 [TIP]
-======
+====
 You can also execute a CQL file using the `xref:astra@cql:cqlsh:cqlsh-commands/source.adoc[]` CQL command:
 
 [source,bash,subs="+quotes"]
@@ -3005,8 +2776,6 @@ astra db cqlsh **DATABASE_ID** -e "SOURCE 'sample.cql'"
 ----
 
 .Result
-[%collapsible]
-====
 [source,cql]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -3019,7 +2788,6 @@ astra db cqlsh **DATABASE_ID** -e "SOURCE 'sample.cql'"
 (2 rows)
 ----
 ====
-======
 
 == Use {dsbulk}
 
@@ -3042,8 +2810,6 @@ astra db load **DATABASE_ID** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Downloading Dsbulk, please wait...
@@ -3063,10 +2829,9 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/LOAD_20250123-020734-995267/checkpoint.csv
 ----
-====
 
 [TIP]
-======
+====
 You can use the `cqlsh` command to check that the data imported successfully:
 
 [source,bash,subs="+quotes"]
@@ -3076,8 +2841,6 @@ astra db cqlsh **DATABASE_ID** -e \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -3108,7 +2871,6 @@ astra db cqlsh **DATABASE_ID** -e \
 (20 rows)
 ----
 ====
-======
 
 Use the `astra db unload` command to unload database table rows into a file:
 
@@ -3121,8 +2883,6 @@ astra db unload **DATABASE_ID** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk unload -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO -delim , -url unloaded_data -header true -encoding UTF-8 -skipRecords 0 -maxErrors 100
@@ -3137,7 +2897,6 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/UNLOAD_20250123-021231-557959/checkpoint.csv
 ----
-====
 
 Use the `astra db count` command to get information about loaded data:
 
@@ -3149,8 +2908,6 @@ astra db count **DATABASE_ID** \
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk count -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO
@@ -3166,13 +2923,10 @@ To resume the current operation, re-run it with the same settings, and add the f
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/COUNT_20250123-021120-127216/checkpoint.csv
 134574
 ----
-====
 
 === `db load` options
 
-.Expand to see all `db load` options
-[%collapsible]
-====
+.All db load options
 [source,console]
 ----
 NAME
@@ -3274,13 +3028,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db unload` options
 
-.Expand to see all `db unload` options
-[%collapsible]
-====
+.All db unload options
 [source,console]
 ----
 NAME
@@ -3381,13 +3132,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db count` options
 
-.Expand to see all `db count` options
-[%collapsible]
-====
+.All db count options
 [source,console]
 ----
 NAME
@@ -3460,7 +3208,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === Complete {dsbulk-short} example
 
@@ -3474,8 +3221,6 @@ astra db create dsbulk_demo_db -k dsbulk_demo_keyspace
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Database 'dsbulk_demo_db' does not exist. Creating database 'dsbulk_demo_db' with keyspace 'dsbulk_demo_keyspace'
@@ -3484,7 +3229,6 @@ astra db create dsbulk_demo_db -k dsbulk_demo_keyspace
 [INFO]  Database 'dsbulk_demo_db' has status 'ACTIVE' (took 471460 millis)
 [OK]    Database 'dsbulk_demo_db' is ready.
 ----
-====
 
 . Download the xref:ROOT:attachment$cities.csv[cities.csv] file and move it to the directory where you run {product} commands.
 +
@@ -3509,8 +3253,6 @@ astra db cqlsh dsbulk_demo_db -k dsbulk_demo_keyspace
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -3519,7 +3261,6 @@ Connected to cndb at 127.0.0.1:9042.
 Use HELP for help.
 token@cqlsh:dsbulk_demo_keyspace>
 ----
-====
 +
 .. Copy and paste the following CQL command into the `cqlsh` prompt and press kbd:[Enter]:
 +
@@ -3556,8 +3297,6 @@ astra db load dsbulk_demo_db \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk load -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO -delim , -url cities.csv -header true -encoding UTF-8 -skipRecords 0 -maxErrors 100
@@ -3575,7 +3314,6 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/LOAD_20250123-020734-995267/checkpoint.csv
 ----
-====
 
 . Confirm that the data loaded successfully:
 +
@@ -3586,8 +3324,6 @@ astra db cqlsh dsbulk_demo_db -e \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -3617,7 +3353,6 @@ astra db cqlsh dsbulk_demo_db -e \
 
 (20 rows)
 ----
-====
 
 . Count the loaded data:
 +
@@ -3629,8 +3364,6 @@ astra db count dsbulk_demo_db \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk count -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO
@@ -3646,7 +3379,6 @@ To resume the current operation, re-run it with the same settings, and add the f
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/COUNT_20250123-021120-127216/checkpoint.csv
 134574
 ----
-====
 
 . Unload the data into CSV files:
 +
@@ -3659,8 +3391,6 @@ astra db unload dsbulk_demo_db \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  RUNNING: /Users/USERNAME/.astra/dsbulk-1.11.0/bin/dsbulk unload -u token -p AstraCS:FZm... -b /Users/USERNAME/.astra/scb/scb_91b35105-a5aa-4cd5-a93b-900ac58452ba_us-east1.zip -k dsbulk_demo_keyspace -t cities_by_country -logDir ./logs --log.verbosity normal --schema.allowMissingFields true -maxConcurrentQueries AUTO -delim , -url unloaded_data -header true -encoding UTF-8 -skipRecords 0 -maxErrors 100
@@ -3675,7 +3405,6 @@ Checkpoints for the current operation were written to checkpoint.csv.
 To resume the current operation, re-run it with the same settings, and add the following command line flag:
 --dsbulk.log.checkpoint.file=/Users/USERNAME/logs/UNLOAD_20250123-021231-557959/checkpoint.csv
 ----
-====
 +
 This command unloads row data from the `cities_by_country` table, and stores it as CSV files within a subsirectory names `unloaded_data` in the same directory where you ran the command.
 
@@ -3703,13 +3432,10 @@ astra db create-cdc **DATABASE_ID** \
 ////
 // TODO: The command is not working as expected. Must investigate and figure out why it is reporting the following error: [ERROR] INVALID_ARGUMENT: Error Code=422(422) Invalid information provided to create DB: 422 Unprocessable Entity: databaseId, keyspace, tableName, and orgId are mandatory fields
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 
 ----
-====
 ////
 
 Use the `astra db list-cdc` command to list the CDC connections for a specifc database:
@@ -3720,8 +3446,6 @@ astra db list-cdc **DATABASE_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +-----------------------+-------------------+----------------+----------------+--------------------+----------------+----------------+
@@ -3730,7 +3454,6 @@ astra db list-cdc **DATABASE_ID**
 | 57a3024f-cdcdemotable | cdc_demo_keyspace | cdc_demo_table | cdc-demo-tenant| pulsar-aws-useast1 | astracdc       | Running        |
 +-----------------------+-------------------+----------------+----------------+--------------------+----------------+----------------+
 ----
-====
 
 Use the `astra db delete-cdc` command to delete a CDC connection for a specific table:
 
@@ -3745,20 +3468,15 @@ astra db delete-cdc **DATABASE_ID** \
 ////
 // TODO: The command is not working as expected. Must investigate and figure out why it is reporting the following error: [ERROR] INVALID_ARGUMENT: Error Code=422(422) Invalid information provided to create DB: 422 Unprocessable Entity: databaseId, keyspace, tableName, and orgId are mandatory fields
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 
 ----
-====
 ////
 
 === `db create-cdc` options
 
-.Expand to see all `db create-cdc` options
-[%collapsible]
-====
+.All db create-cdc options
 [source,console]
 ----
 NAME
@@ -3815,13 +3533,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db list-cdc` options
 
-.Expand to see all `db list-cdc` options
-[%collapsible]
-====
+.All db list-cdc options
 [source,console]
 ----
 NAME
@@ -3863,13 +3578,10 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === `db delete-cdc` options
 
-.Expand to see all `db delete-cdc` options
-[%collapsible]
-====
+.All db delete-cdc options
 [source,console]
 ----
 NAME
@@ -3925,7 +3637,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 === Complete CDC configuration example
 
@@ -3942,8 +3653,6 @@ astra db create cdc_demo_db \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 REGION OK
@@ -3954,7 +3663,6 @@ get CLoud provider
 [INFO]  Database 'cdc_demo_db' has status 'ACTIVE' (took 112117 millis)
 [OK]    Database 'cdc_demo_db' is ready.
 ----
-====
 
 . Create an {astra-stream} tenant in the same region as your database:
 +
@@ -3966,14 +3674,11 @@ astra streaming create cdc-demo-tenant \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 https://api.astra.datastax.com/v2/streaming/tenants/cdc-demo-tenant
 [OK]    Tenant 'cdc-demo-tenant' has being created.
 ----
-====
 
 . Use `xref:ROOT:managing.adoc#cqlsh[cqlsh]` to create a table with a primary key column in your database.
 +
@@ -3987,13 +3692,10 @@ astra db cqlsh cdc_demo_db -e \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
 ----
-====
 
 . Confirm table creation:
 +
@@ -4004,8 +3706,6 @@ astra db cqlsh cdc_demo_db -e \
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Cqlsh is starting, please wait for connection establishment...
@@ -4015,7 +3715,6 @@ astra db cqlsh cdc_demo_db -e \
 
 (0 rows)
 ----
-====
 
 . Create a CDC connection.
 +
@@ -4030,13 +3729,10 @@ astra db create-cdc cdc_demo_db \
 ////
 // TODO: The command is not working as expected. Must investigate and figure out why it is reporting the following error: [ERROR] INVALID_ARGUMENT: Error Code=422(422) Invalid information provided to create DB: 422 Unprocessable Entity: databaseId, keyspace, tableName, and orgId are mandatory fields
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 
 ----
-====
 ////
 
 . Confirm CDC details for the database and tenant.
@@ -4047,8 +3743,6 @@ astra db list-cdc cdc_demo_db
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +-----------------------+-------------------+----------------+----------------+--------------------+----------------+----------------+
@@ -4057,7 +3751,6 @@ astra db list-cdc cdc_demo_db
 | 57a3024f-cdcdemotable | cdc_demo_keyspace | cdc_demo_table | cdc-demo-tenant| pulsar-aws-useast1 | astracdc       | Running        |
 +-----------------------+-------------------+----------------+----------------+--------------------+----------------+----------------+
 ----
-====
 +
 [source,bash]
 ----
@@ -4065,8 +3758,6 @@ astra streaming list-cdc cdc-demo-tenant
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +--------------------+----------------+----------------+-------------------+----------------+----------------+
@@ -4075,7 +3766,6 @@ astra streaming list-cdc cdc-demo-tenant
 | pulsar-aws-useast1 | astracdc       | cdc_demo_db    | cdc_demo_keyspace | cdc_demo_table | running        |
 +--------------------+----------------+----------------+-------------------+----------------+----------------+
 ----
-====
 
 After you enable CDC on your {db-serverless} database, you can xref:astra-db-serverless:databases:change-data-capture.adoc#connect-a-sink[connect a sink].
 
@@ -4091,13 +3781,10 @@ astra db download-scb **DATABASE_ID** -r **REGION_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Bundle downloaded in ./scb_a53003fe-ba42-4c3c-85d0-6b345622c2dc_dc-1.zip
 ----
-====
 
 The `-r **REGION_NAME**` option is required for <<configure-multiple-regions,multi-region databases>>.
 If your database is configured with multiple regions, replace `**REGION_NAME**` with the name of the region you want to download the {scb-short} for.
@@ -4113,9 +3800,7 @@ The {scb-short} contains sensitive information that establishes a connection to 
 
 === `db download-scb` options
 
-.Expand to see all `db download-scb` options
-[%collapsible]
-====
+.All db download-scb options
 [source,console]
 ----
 NAME
@@ -4165,7 +3850,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-r` / `--region` option to download the {scb-short} for a specific region:
 
@@ -4175,13 +3859,10 @@ astra db download-scb **DATABASE_ID** -r **REGION_NAME**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Bundle downloaded in ./scb_a53003fe-ba42-4c3c-85d0-6b345622c2dc_dc-1.zip
 ----
-====
 
 [TIP]
 ====
@@ -4197,13 +3878,10 @@ astra db download-scb **DATABASE_ID** -f **DESTINATION_FILE**.zip
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO]  Bundle downloaded in DESTINATION_FILE.zip
 ----
-====
 
 == Create environment variables
 
@@ -4223,10 +3901,7 @@ By default, the {product} saves the `.env` file to the directory where you run t
 
 If a `.env` file already exists in the directory, the {product} appends the new environment variables to the existing file.
 
-.Result
-[%collapsible%open]
-====
-..env
+.Result (.env)
 [source,console]
 ----
 ASTRA_DB_API_ENDPOINT="https://a53003fe-ba42-4c3c-85d0-6b345622c2dc-us-east1.apps.astra.datastax.com/api/json"
@@ -4246,7 +3921,6 @@ ASTRA_ORG_ID="2dbd3c55-6a68-4b5b-9155-5be9d41823e8"
 ASTRA_ORG_NAME="alice@example.com"
 ASTRA_ORG_TOKEN="AstraCS:FZm..."
 ----
-====
 
 [WARNING]
 ====
@@ -4260,9 +3934,7 @@ The {scb-short} contains sensitive information that establishes a connection to 
 The directory must already exist before you run the `db create-dotenv` command.
 If the directory doesn't exist, the command fails with the error `INVALID_ARGUMENT: Destination folder has not been found`.
 
-.Expand to see all `db create-dotenv` options
-[%collapsible]
-====
+.All db create-dotenv options
 [source,console]
 ----
 NAME
@@ -4316,7 +3988,6 @@ OPTIONS
         <DB>
             Database name (if unique) or Database identifier
 ----
-====
 
 Use the `-d` / `--directory` option to save the `.env` file to a specific directory:
 
@@ -4326,10 +3997,7 @@ astra db create-dotenv **DATABASE_ID** -d ~/tmp
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [OK]    File '/Users/USERNAME/tmp/.env' has been created/amended
 ----
-====

--- a/in-progress/quickstart-databases.adoc
+++ b/in-progress/quickstart-databases.adoc
@@ -111,8 +111,6 @@ You can also get metadata by providing the database name, but this doesn't guara
 |===
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +------------------+-----------------------------------------+
@@ -134,7 +132,6 @@ You can also get metadata by providing the database name, but this doesn't guara
 |                  |                                         |
 +------------------+-----------------------------------------+
 ----
-====
 
 === Find all databases
 
@@ -148,8 +145,6 @@ astra db list
 ----
 
 .Result
-[%collapsible]
-====
 [source,console,subs="+quotes"]
 ----
 +---------------------+--------------+-----------+-------+---+-----------+
@@ -159,7 +154,6 @@ astra db list
 +---------------------+--------------+-----------+-------+---+-----------+
 ----
 //ID truncated to prevent bad wrapping.
-====
 
 == Drop a database
 
@@ -248,8 +242,6 @@ See xref:databases:create-database.adoc#get-db-id[Get your database ID].
 |===
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 +----------------------------+
@@ -259,7 +251,6 @@ See xref:databases:create-database.adoc#get-db-id[Get your database ID].
 | keyspace2                 |
 +----------------------------+
 ----
-====
 
 == Drop a keyspace
 

--- a/modules/ROOT/pages/install.adoc
+++ b/modules/ROOT/pages/install.adoc
@@ -44,18 +44,12 @@ Scripted installation (recommended)::
 curl -sSL https://ibm.biz/astra-cli | sh
 ----
 +
-.Install to a custom location
-[%collapsible]
-====
-To install the {product} to a custom location, export the `ASTRA_HOME` environment variable before running the installation command:
-
+To install the {product} to a custom location, export the `ASTRA_HOME` environment variable before running the installation command, replacing `**INSTALLATION_DIRECTORY**` with the full path to your preferred installation directory:
++
 [source,bash,subs="+quotes"]
 ----
 export ASTRA_HOME=**INSTALLATION_DIRECTORY**
 ----
-
-Replace `**INSTALLATION_DIRECTORY**` with the full path to your preferred installation directory.
-====
 
 . Add the `astra` executable to your `PATH` by running the command supplied after installation:
 +
@@ -114,7 +108,7 @@ xattr -d com.apple.quarantine $(which astra)
 +
 Alternatively, you can remove these restrictions in your https://support.apple.com/en-us/102445#openanyway[macOS System Settings].
 +
-If you don't remove the restrictions, you will receive a security alert stating `“astra” Not Opened` when you run the `astra` command.
+If you don't remove the restrictions, you will receive a security alert stating `"astra" Not Opened` when you run the `astra` command.
 
 . Reload your shell profile or open a new terminal window.
 
@@ -145,18 +139,12 @@ Scripted installation (recommended)::
 powershell -c "irm https://ibm.biz/astra-cli-win | iex"
 ----
 +
-.Install to a custom location
-[%collapsible]
-====
-To install the {product} to a custom location, export the `ASTRA_HOME` environment variable before running the installation command:
-
+To install the {product} to a custom location, export the `ASTRA_HOME` environment variable before running the installation command, replacing `**INSTALLATION_DIRECTORY**` with the full path to your preferred installation directory:
++
 [source,powershell,subs="+quotes"]
 ----
 $env:ASTRA_HOME = "**INSTALLATION_DIRECTORY**"
 ----
-
-Replace `**INSTALLATION_DIRECTORY**` with the full path to your preferred installation directory.
-====
 
 . Open a new terminal window.
 

--- a/modules/ROOT/pages/install.adoc
+++ b/modules/ROOT/pages/install.adoc
@@ -23,20 +23,12 @@ The {product} supports the following operating systems:
 |`x86_64`
 |===
 
-== Install the CLI
+== Install the {product} on macOS or Linux
 
-[tabs,sync-group-id=platforms]
-======
-macOS and Linux::
-+
-Select one of the following installation methods to install the {product} on macOS and Linux.
-If you prefer to use a package manager, follow the Homebrew instructions instead.
-+
-[tabs]
-=====
-Scripted installation (recommended)::
-+
---
+To install the {product} on macOS and Linux, you can use a scripted installation, binary installation, or a package manager.
+
+=== Scripted installation on macOS and Linux (recommended)
+
 . Run the following command to install the latest version of the {product} to the default location:
 +
 [source,shell]
@@ -68,11 +60,9 @@ astra
 ----
 +
 The response includes available commands and options for the {product}.
---
 
-Binary installation::
-+
---
+=== Binary installation on macOS and Linux
+
 . Download the appropriate binary archive for your OS and CPU architecture from {product-repo}/releases[GitHub].
 
 . Extract the archive into the directory where you want to install the {product}.
@@ -120,18 +110,31 @@ astra
 ----
 +
 The response includes available commands and options for the {product}.
---
-=====
 
-Windows::
+=== Install with Homebrew
+
+. Install the latest version of the {product} using https://brew.sh/[Homebrew]:
 +
-Select one of the following installation methods to install the {product} on Windows:
+[source,shell]
+----
+brew install datastax/astra-cli/astra
+----
+
+. Run the `astra` command from any directory to verify successful installation:
 +
-[tabs]
-=====
-Scripted installation (recommended)::
+[source,shell]
+----
+astra
+----
 +
---
+The response includes available commands and options for the {product}.
+
+== Install the {product} on Windows
+
+To install the {product} on Windows, you can use a scripted installation or binary installation.
+
+=== Scripted installation on Windows (recommended)
+
 . Run the following command to install the latest version of the {product} to the default location:
 +
 [source,powershell]
@@ -156,11 +159,9 @@ astra
 ----
 +
 The response includes available commands and options for the {product}.
---
 
-Binary installation::
-+
---
+=== Binary installation on Windows
+
 . Download the `windows` zip file from {product-repo}/releases[GitHub].
 
 . Extract the zip file into the directory where you want to install the {product}:
@@ -185,29 +186,6 @@ astra
 ----
 +
 The response includes available commands and options for the {product}.
---
-=====
-
-Homebrew::
-+
---
-. Install the latest version of the {product} using https://brew.sh/[Homebrew]:
-+
-[source,shell]
-----
-brew install datastax/astra-cli/astra
-----
-
-. Run the `astra` command from any directory to verify successful installation:
-+
-[source,shell]
-----
-astra
-----
-+
-The response includes available commands and options for the {product}.
---
-======
 
 == Next steps
 

--- a/modules/ROOT/pages/manage-cli.adoc
+++ b/modules/ROOT/pages/manage-cli.adoc
@@ -66,8 +66,6 @@ astra setup
 ----
 +
 .Result
-[%collapsible%open]
-====
 [source,console]
 ----
      _____            __
@@ -85,44 +83,34 @@ Your configuration file will be created at /Users/username/.astrarc
 
 Press Enter to continue, or use Ctrl+C to cancel.
 ----
-====
 
 . Press kbd:[Enter] to continue.
 +
 .Result
-[%collapsible%open]
-====
 [source,console]
 ----
 (Required) Enter your Astra token (it should start with AstraCS)
 > input hidden for security
 ----
-====
 
 . Enter your application token (`AstraCS:...`), and then press kbd:[Enter].
 +
 .Result
-[%collapsible%open]
-====
 [source,console]
 ----
 (Optional) Enter a name for your profile (defaults to your org name)
 >
 ----
-====
 
 . Enter a name for your configuration profile, or press kbd:[Enter] to accept the default (your organization name).
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Profile 'PROFILE_NAME' successfully created.
 
 It has been set as the default profile.
 ----
-====
 +
 The {product} automatically sets the configuration profile as the default.
 All subsequent commands use this profile unless you <<specify-configuration-profile-individual-command,override it>>.
@@ -136,8 +124,6 @@ astra db list-clouds
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 ┌─────────────────┐
@@ -148,7 +134,6 @@ astra db list-clouds
 │ aws             │
 └─────────────────┘
 ----
-====
 +
 If the command succeeds, your connection is configured correctly.
 
@@ -172,16 +157,15 @@ See <<specify-configuration-profile-individual-command>>.
 
 == Get command help
 
+Get general help::
 Run `astra` by itself to print general help information:
-
++
 [source,shell]
 ----
 astra
 ----
-
++
 .Result
-[%collapsible]
-====
 [source,console]
 ----
      _____            __
@@ -240,18 +224,16 @@ Examples:
 
 See 'astra <command> <subcommand> --help' for help on a specific subcommand.
 ----
-====
 
-Append the `-h` / `--help` option to any command or subcommand to get specific help information and examples:
-
+Get help for a specific command::
+Append the `-h` / `--help` option to any command to get specific help information and examples:
++
 [source,shell]
 ----
 astra org -h
 ----
-
++
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Usage: astra org [-qV] [--no-input] [--[no-]spinner] [--dump-logs[=FILE]]
@@ -303,16 +285,16 @@ Examples:
 
 See 'astra <command> <subcommand> --help' for help on a specific subcommand.
 ----
-====
 
+Get help for a specific subcommand::
+Append the `-h` / `--help` option to any subcommand to get specific help information and examples:
++
 [source,shell]
 ----
 astra db list --help
 ----
-
++
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Usage: astra db list [-qvV] [--no-input] [--[no-]spinner] [--dump-logs[=FILE]]
@@ -356,7 +338,6 @@ Examples:
 
 See 'astra <command> <subcommand> --help' for help on a specific subcommand.
 ----
-====
 
 [#command-auto-completion]
 == Use command auto-completion
@@ -403,8 +384,6 @@ astra config list
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 ┌─────────────────────┐
@@ -414,7 +393,6 @@ astra config list
 │ Testing             │
 └─────────────────────┘
 ----
-====
 
 The default configuration profile is indicated by `(in use)`.
 
@@ -446,8 +424,6 @@ astra config create '**PROFILE_NAME**' --token **APPLICATION_TOKEN**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Configuration profile 'PROFILE_NAME' successfully created.
@@ -457,7 +433,6 @@ Configuration profile 'PROFILE_NAME' successfully created.
 # Set it as the default profile:
 $ astra config use 'PROFILE_NAME'
 ----
-====
 
 You can also use the `xref:commands:astra-setup.adoc[]` command again to create additional configuration profiles interactively.
 
@@ -488,13 +463,10 @@ astra config use '**PROFILE_NAME**'
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Default profile set to 'PROFILE_NAME'.
 ----
-====
 
 [#specify-configuration-profile-individual-command]
 === Specify a configuration profile for an individual command
@@ -523,13 +495,10 @@ astra config delete '**PROFILE_NAME**'
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Profile 'PROFILE_NAME' deleted successfully.
 ----
-====
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/manage-cli.adoc
+++ b/modules/ROOT/pages/manage-cli.adoc
@@ -30,7 +30,6 @@ If you're using the {product} in production, {company} strongly recommends that 
 For example, don't grant an administrator-level role to a token that won't be used to execute those types of commands.
 ====
 
-//TODO: Turn this section into tabs
 [#connect-to-astra]
 == Connect the {product}
 
@@ -550,69 +549,51 @@ For more information about the {product} configuration file, see the {product-re
 
 === Override the default home folder location
 
-You can override the default location of the {product} home folder (`.astra`) by setting the `ASTRA_HOME` environment variable.
+You can override the default location of the {product} home folder (`.astra`) by setting the `ASTRA_HOME` environment variable:
 
-[tabs]
-======
 Set the environment variable dynamically::
-+
---
 Add the following line to your shell profile:
-
++
 [source,bash,subs="+quotes"]
 ----
 eval "$(astra shellenv --home "**HOME_FOLDER_PATH**")"
 ----
-
++
 Replace `**HOME_FOLDER_PATH**` with the full path to your preferred {product} home folder.
---
 
 Set the environment variable directly::
-+
---
 Add the following line to your shell profile:
-
++
 [source,bash,subs="+quotes"]
 ----
 export ASTRA_HOME=**HOME_FOLDER_PATH**
 ----
-
++
 Replace `**HOME_FOLDER_PATH**` with the full path to your preferred {product} home folder.
---
-======
 
 === Override the default configuration file location
 
-You can override the default location of the {product} configuration file (`.astrarc`) by setting the `ASTRA_CONFIG_FILE` environment variable.
+You can override the default location of the {product} configuration file (`.astrarc`) by setting the `ASTRA_CONFIG_FILE` environment variable:
 
-[tabs]
-======
 Set the environment variable dynamically::
-+
---
 Add the following line to your shell profile:
-
++
 [source,bash,subs="+quotes"]
 ----
 eval "$(astra shellenv --rc "**CONFIG_FILE_PATH**/.astrarc")"
 ----
-
++
 Replace `**CONFIG_FILE_PATH**` with the full path to your preferred `.astrarc` configuration file.
---
 
 Set the environment variable directly::
-+
---
 Add the following line to your shell profile:
-
++
 [source,bash,subs="+quotes"]
 ----
 export ASTRARC=**CONFIG_FILE_PATH**/.astrarc
 ----
-
++
 Replace `**CONFIG_FILE_PATH**` with the full path to your preferred `.astrarc` configuration file.
---
-======
 
 [#command-output]
 == Command output formats and exit codes
@@ -626,23 +607,16 @@ astra COMMAND -o **FORMAT**
 
 The following output formats are available:
 
-* `human` (default): Human-readable format, optimized for command-line readability.
-* `json`: Structured JSON format, suitable for programmatic parsing.
-* `csv`: Comma-separated output format, ideal for data export and analysis.
-
-[tabs]
-======
-Human-readable::
+`human` (default)::
+Human-readable format, optimized for command-line readability.
 +
---
-The human-readable format uses tables, lists, and other visual elements to present information on the command line.
---
+This format uses tables, lists, and other visual elements to present information on the command line.
 
-JSON::
+`json`::
+Structured JSON format, suitable for programmatic parsing.
 +
---
-Every command supporting JSON output will always return a response of exactly this schema:
-
+Every command that supports JSON output always returns a response using exactly this schema:
++
 .JSON output schema
 [source,json]
 ----
@@ -660,9 +634,10 @@ Every command supporting JSON output will always return a response of exactly th
   ]
 }
 ----
-
++
 All field names in the JSON output are in camel case (`fieldName`).
-
++
+.JSON output fields
 [cols="1,1,2"]
 |===
 |Name |Type |Summary
@@ -700,27 +675,27 @@ If present, it is an array of recommended next-step objects containing the follo
 * `command`: The command to run.
 * `comment`: An explanation of why/when to run this next.
 |===
---
 
-CSV::
+`csv`::
+Comma-separated output format, ideal for data export and analysis.
 +
---
-Every command supporting CSV output will always return an RFC-4180-compliant response of exactly this schema:
-
+Every command that supports CSV output always returns an RFC-4180-compliant response using exactly this schema:
++
 .CSV output schema
 [source,csv]
 ----
 code,message,data_field_1,data_field_2,...
 ----
-
++
 All field names in the CSV output are in snake case (`field_name`).
-
++
 The first row is always the header, defining the column names.
 Each subsequent row represents one data record from the command.
-
-The `code` and `message` fields may repeat for each row of data to keep the CSV schema consistent.
-Values may contain commas or newlines and be wrapped in quotes to ensure RFC-4180-compliant CSV output.
-
++
+The `code` and `message` fields can repeat for each row of data to keep the CSV schema consistent.
+Values can contain commas or newlines, and they can be wrapped in quotes to ensure RFC-4180-compliant CSV output.
++
+.CSV output fields
 [cols="1,1,2"]
 |===
 |Name |Type |Summary
@@ -736,25 +711,23 @@ Common values include:
 * `DATABASE_NOT_FOUND`: referenced resource missing
 * Other command-specific codes
 
-If no rows are returned, you should assume an implicit `OK` code.
+If no rows are returned, you can assume an implicit `OK` code.
 
 |`message`
 |`string`
 |Optional.
 A human-friendly message describing the result or error of the command.
 
-Not all commands include a message, and this field will be empty if there is nothing to report.
+Not all commands include a `message`, and this field is empty if there is nothing to report.
 
 |Additional data fields
 |Any (type varies by command)
 a|Command-specific fields representing the actual data returned.
 
-Fields may be empty if there is nothing to report.
+Fields can be empty if there is nothing to report.
 
 Column order is consistent per command.
 |===
---
-======
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/uninstall.adoc
+++ b/modules/ROOT/pages/uninstall.adoc
@@ -3,17 +3,14 @@
 
 Follow the instructions for your original installation method to uninstall the {product}.
 
-[tabs,sync-group-id=platforms]
-======
-macOS and Linux::
-+
-Select one of the following methods to uninstall the {product} on macOS and Linux:
-+
-[tabs]
-=====
-`astra nuke` command (recommended)::
-+
---
+== Uninstall on macOS and Linux
+
+Use these methods if you _did not_ install the {product} with a package manager.
+
+To uninstall the {product} on macOS and Linux, you can use either `astra nuke` or manually remove the files.
+
+=== Use astra nuke on macOS and Linux (recommended)
+
 . Run the `xref:commands:astra-nuke.adoc[]` command:
 +
 [source,shell]
@@ -42,7 +39,7 @@ This action is irreversible and will delete all Astra CLI files from your system
 ↑↓ to navigate, Enter to select, type to filter
 ----
 
-. When prompted to continue, select kbd:[yes] and press kbd:[Enter].
+. When prompted to continue, select kbd:[yes], and then press kbd:[Enter].
 +
 .Result
 [source,console]
@@ -56,11 +53,9 @@ Your credentials may be lost if you do. A backup is recommended.
 > no (default)
 ----
 
-. Select whether to delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file.
+. Select whether to delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file, and then press kbd:[Enter] to continue.
 +
 Only select kbd:[yes] if you don't want to preserve your xref:ROOT:manage-cli.adoc#manage-configuration-profiles[configuration profiles].
-+
-Press kbd:[Enter] to continue.
 +
 .Result
 [source,console]
@@ -78,11 +73,9 @@ Files skipped:
 ----
 
 . Optional: If the `astra nuke` command found any shell profiles containing references to the `astra` command, you can manually delete these references.
---
 
-Manual removal::
-+
---
+=== Manual removal on macOS and Linux
+
 . Optional: If you don't want to preserve your xref:ROOT:manage-cli.adoc#manage-configuration-profiles[configuration profiles], delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file:
 +
 [source,shell]
@@ -106,18 +99,13 @@ rm -f $(which astra)
 
 . Optional: Manually remove any references to the `astra` command from your shell profile.
 For example, from `~/.zprofile` or `~/.bash_profile`.
---
-=====
 
-Windows::
-+
-Select one of the following methods to uninstall the {product} on Windows:
-+
-[tabs]
-=====
-Uninstaller (recommended)::
-+
---
+== Uninstall on Windows
+
+To uninstall the {product} on Windows, you can use the uninstaller, the `astra nuke` command, or manually remove the files:
+
+=== Use the Windows uninstaller (recommended)
+
 Only use this method if you installed the {product} using the xref:ROOT:install.adoc[scripted installer].
 
 . Optional: If you don't want to preserve your xref:ROOT:manage-cli.adoc#manage-configuration-profiles[configuration profiles], delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file:
@@ -129,11 +117,9 @@ rm -f $(astra config path -p)
 
 . In your Windows **Settings**, uninstall the {product} app.
 For specific instructions, see https://support.microsoft.com/en-us/windows/uninstall-or-remove-apps-and-programs-in-windows-4b55f974-2cc6-2d2b-d092-5905080eaf98[Uninstall or remove apps and programs in Windows].
---
 
-`astra nuke` command::
-+
---
+=== Use astra nuke on Windows
+
 . Run the `xref:commands:astra-nuke.adoc[]` command:
 +
 [source,powershell]
@@ -176,11 +162,9 @@ Your credentials may be lost if you do. A backup is recommended.
 > no (default)
 ----
 
-. Select whether to delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file.
+. Select whether to delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file, and then press kbd:[Enter] to continue.
 +
 Only select kbd:[yes] if you don't want to preserve your xref:ROOT:manage-cli.adoc#manage-configuration-profiles[configuration profiles].
-+
-Press kbd:[Enter] to continue.
 +
 .Result
 [source,console]
@@ -199,11 +183,9 @@ Files skipped:
 
 . Optional: Manually remove `astra` from your system `PATH`.
 For more information, see the https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables[Microsoft PowerShell documentation].
---
 
-Manual removal::
-+
---
+=== Manual removal on Windows
+
 . Optional: If you don't want to preserve your xref:ROOT:manage-cli.adoc#manage-configuration-profiles[configuration profiles], delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file:
 +
 [source,powershell]
@@ -227,12 +209,11 @@ rm -f (Get-Command astra).Source
 
 . Optional: Manually remove `astra` from your system `PATH`.
 For more information, see the https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables[Microsoft PowerShell documentation].
---
-=====
 
-Homebrew::
-+
---
+== Uninstall with Homebrew
+
+Only use this method if you installed the {product} with Homebrew.
+
 . Delete the {product} home folder (`xref:ROOT:manage-cli.adoc#file-locations[~/.astra]`) and optionally its configuration file (`xref:ROOT:manage-cli.adoc#file-locations[~/.astrarc]`):
 +
 .. Run the `xref:commands:astra-nuke.adoc[]` command:
@@ -303,5 +284,3 @@ To complete the uninstallation, please use Homebrew to uninstall the Astra CLI b
 ----
 brew uninstall datastax/astra-cli/astra
 ----
---
-======

--- a/modules/ROOT/pages/uninstall.adoc
+++ b/modules/ROOT/pages/uninstall.adoc
@@ -22,8 +22,6 @@ astra nuke
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
      _____            __
@@ -43,13 +41,10 @@ This action is irreversible and will delete all Astra CLI files from your system
 
 ↑↓ to navigate, Enter to select, type to filter
 ----
-====
 
 . When prompted to continue, select kbd:[yes] and press kbd:[Enter].
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Do you also want to delete the .astrarc file located at /Users/username/.astrarc?
@@ -60,7 +55,6 @@ Your credentials may be lost if you do. A backup is recommended.
   yes
 > no (default)
 ----
-====
 
 . Select whether to delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file.
 +
@@ -69,8 +63,6 @@ Only select kbd:[yes] if you don't want to preserve your xref:ROOT:manage-cli.ad
 Press kbd:[Enter] to continue.
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Astra CLI Nuke Summary
@@ -84,7 +76,6 @@ Shell profiles containing astra:
 Files skipped:
 → /Users/username/.astrarc - User chose to keep the file
 ----
-====
 
 . Optional: If the `astra nuke` command found any shell profiles containing references to the `astra` command, you can manually delete these references.
 --
@@ -151,8 +142,6 @@ astra nuke
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
      _____            __
@@ -172,13 +161,10 @@ This action is irreversible and will delete all Astra CLI files from your system
 
 ↑↓ to navigate, Enter to select, type to filter
 ----
-====
 
 . When prompted to continue, select kbd:[yes] and press kbd:[Enter].
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Do you also want to delete the .astrarc file located at <astra_cli_config_path>?
@@ -189,7 +175,6 @@ Your credentials may be lost if you do. A backup is recommended.
   yes
 > no (default)
 ----
-====
 
 . Select whether to delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file.
 +
@@ -198,8 +183,6 @@ Only select kbd:[yes] if you don't want to preserve your xref:ROOT:manage-cli.ad
 Press kbd:[Enter] to continue.
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Astra CLI Nuke Summary
@@ -213,7 +196,6 @@ Shell profiles containing astra:
 Files skipped:
 → <astra_cli_config_path> - User chose to keep the file
 ----
-====
 
 . Optional: Manually remove `astra` from your system `PATH`.
 For more information, see the https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables[Microsoft PowerShell documentation].
@@ -261,8 +243,6 @@ astra nuke
 ----
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
      _____            __
@@ -282,13 +262,10 @@ This action is irreversible and will delete all Astra CLI files from your system
 
 ↑↓ to navigate, Enter to select, type to filter
 ----
-====
 +
 .. When prompted to continue, select kbd:[yes] and press kbd:[Enter].
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Do you also want to delete the .astrarc file located at /Users/username/.astrarc?
@@ -299,7 +276,6 @@ Your credentials may be lost if you do. A backup is recommended.
   yes
 > no (default)
 ----
-====
 +
 .. Select whether to delete the `xref:ROOT:manage-cli.adoc#file-locations[.astrarc]` file.
 +
@@ -308,8 +284,6 @@ Only select kbd:[yes] if you don't want to preserve your xref:ROOT:manage-cli.ad
 Press kbd:[Enter] to continue.
 +
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Astra CLI Nuke Summary
@@ -322,7 +296,6 @@ Files skipped:
 
 To complete the uninstallation, please use Homebrew to uninstall the Astra CLI binary.
 ----
-====
 
 . Uninstall the {product} using Homebrew:
 +

--- a/modules/ROOT/pages/upgrade-pre-1.0.adoc
+++ b/modules/ROOT/pages/upgrade-pre-1.0.adoc
@@ -12,23 +12,21 @@ If you have an earlier version installed, you must delete the `astra` executable
 macOS and Linux::
 +
 --
+Delete the `astra` executable:
+
 [source,shell]
 ----
 rm ~/.astra/cli/astra
 ----
 
-.Delete custom installation
-[%collapsible]
-====
 If you installed the {product} to a custom location, you can use the following command to delete the `astra` executable if it exists in your PATH:
 
 [source,shell]
 ----
 rm $(which astra)
 ----
-====
 
-This command does not delete your xref:ROOT:manage-cli.adoc#file-locations[{product} home folder and configuration file] (`.astra` and `.astrarc`).
+The `rm` command does not delete your xref:ROOT:manage-cli.adoc#file-locations[{product} home folder and configuration file] (`.astra` and `.astrarc`).
 Leave these files in place so that the new version of the {product} can continue to connect using your existing configuration.
 --
 

--- a/modules/ROOT/pages/upgrade-pre-1.0.adoc
+++ b/modules/ROOT/pages/upgrade-pre-1.0.adoc
@@ -7,41 +7,33 @@
 
 If you have an earlier version installed, you must delete the `astra` executable before you can install the latest version:
 
-[tabs,sync-group-id=platforms]
-======
 macOS and Linux::
-+
---
 Delete the `astra` executable:
-
++
 [source,shell]
 ----
 rm ~/.astra/cli/astra
 ----
-
++
 If you installed the {product} to a custom location, you can use the following command to delete the `astra` executable if it exists in your PATH:
-
++
 [source,shell]
 ----
 rm $(which astra)
 ----
-
++
 The `rm` command does not delete your xref:ROOT:manage-cli.adoc#file-locations[{product} home folder and configuration file] (`.astra` and `.astrarc`).
 Leave these files in place so that the new version of the {product} can continue to connect using your existing configuration.
---
 
 Homebrew::
 +
---
 [source,shell]
 ----
 brew uninstall datastax/astra-cli/astra-cli
 ----
-
++
 Uninstalling with Homebrew does not delete your xref:ROOT:manage-cli.adoc#file-locations[{product} home folder and configuration file] (`.astra` and `.astrarc`).
 Leave these files in place so that the new version of the {product} can continue to connect using your existing configuration.
---
-======
 
 After you delete the old `astra` executable, follow the instructions in xref:ROOT:install.adoc[] to install the latest version.
 

--- a/modules/ROOT/pages/upgrade.adoc
+++ b/modules/ROOT/pages/upgrade.adoc
@@ -12,7 +12,7 @@ If you used a package manager to install the {product}, such as Homebrew, then y
 
 == Upgrade with astra upgrade
 
-You can use the `xref:commands:astra-upgrade.adoc[]` command on Linux, macOS, or Microsoft Windows if you _did not_ install the {product} with a package manager.
+You can use the `xref:commands:astra-upgrade.adoc[]` command on macOS, Linux, or Microsoft Windows if you _did not_ install the {product} with a package manager.
 
 On Windows, run the following commands in a PowerShell terminal.
 

--- a/modules/ROOT/pages/upgrade.adoc
+++ b/modules/ROOT/pages/upgrade.adoc
@@ -10,19 +10,20 @@ If you're upgrading from version 0.6 or earlier, see xref:ROOT:upgrade-pre-1.0.a
 If you used a package manager to install the {product}, such as Homebrew, then you must use the same package manager to upgrade the {product}.
 ====
 
-[tabs,sync-group-id=platforms]
-======
-macOS and Linux::
-+
---
+== Upgrade with astra upgrade
+
+You can use the `xref:commands:astra-upgrade.adoc[]` command on Linux, macOS, or Microsoft Windows if you _did not_ install the {product} with a package manager.
+
+On Windows, run the following commands in a PowerShell terminal.
+
 . Run the `xref:commands:astra-upgrade.adoc[]` command to upgrade to the latest version of the {product}:
 +
 [source,shell]
 ----
 astra upgrade
 ----
-
-. Optional: Upgrade to a specific version of the {product}:
++
+To upgrade to a specific version, use the `--version` option:
 +
 [source,shell,subs="+quotes"]
 ----
@@ -39,40 +40,9 @@ astra --version
 ----
 +
 The response returns your {product} version.
---
 
-Windows::
-+
---
-. Run the `xref:commands:astra-upgrade.adoc[]` command to upgrade to the latest version of the {product}:
-+
-[source,powershell]
-----
-astra upgrade
-----
+== Upgrade with Homebrew
 
-. Optional: Upgrade to a specific version of the {product}:
-+
-[source,powershell,subs="+quotes"]
-----
-astra upgrade --version **VERSION**
-----
-+
-You can also use this command to downgrade to a previous version.
-
-. Check the {product} version to verify that the upgrade was successful:
-+
-[source,powershell]
-----
-astra --version
-----
-+
-The response returns your {product} version.
---
-
-Homebrew::
-+
---
 . Run the following command to upgrade to the latest version of the {product}:
 +
 [source,shell]
@@ -88,5 +58,3 @@ astra --version
 ----
 +
 The response returns your {product} version.
---
-======

--- a/modules/quickstarts/pages/cqlsh.adoc
+++ b/modules/quickstarts/pages/cqlsh.adoc
@@ -34,9 +34,6 @@ If the {product} reports `ModuleNotFoundError` after running any of the `astra d
 The error `A Python installation with SSL is required to connect to a cloud cluster` means that the detected Python version doesn't support TLS.
 This typically happens with Python versions earlier than 2.7.12, which don't support TLS.
 
-.Verify TLS support
-[%collapsible]
-====
 To verify whether your current Python version supports TLS, run the following command:
 
 [source,shell]
@@ -52,7 +49,6 @@ Traceback (most recent call last):
   File "<string>", line 1, in <module>
 ImportError: cannot import name PROTOCOL_TLS
 ----
-====
 
 == Start an interactive `cqlsh` session
 
@@ -64,8 +60,6 @@ astra db cqlsh start **DB_ID**
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 [INFO] Patched cqlsh script to try known supported Python versions first
@@ -74,7 +68,6 @@ Connected to cndb at 127.0.0.1:9042.
 Use HELP for help.
 token@cqlsh>
 ----
-====
 
 To exit `cqlsh`, type `exit` or `quit;` and then press kbd:[Enter].
 
@@ -88,15 +81,12 @@ astra db cqlsh exec **DB_ID** "describe keyspaces;"
 ----
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 system_auth    data_endpoint_auth  default_keyspace  system_views
 my_keyspace    system              system_traces     system_virtual_schema
 system_schema  datastax_sla        my_keyspace2
 ----
-====
 
 CQL statements must be enclosed in double quotes (`""`).
 
@@ -109,10 +99,7 @@ Use the `-f` / `--file` option with the `xref:commands:astra-db-cqlsh-exec.adoc[
 astra db cqlsh exec **DB_ID** -f sample.cql
 ----
 
-.Example CQL file
-[%collapsible]
-====
-.sample.cql
+.Example CQL file (sample.cql)
 [source,cql]
 ----
 -- Use a specific keyspace
@@ -132,11 +119,8 @@ INSERT INTO users (id, name, email) VALUES (uuid(), 'Bob', 'bob@example.com');
 -- Query the data
 SELECT * FROM users;
 ----
-====
 
 .Result
-[%collapsible]
-====
 [source,console]
 ----
  id                                   | email             | name
@@ -146,20 +130,19 @@ SELECT * FROM users;
 
 (2 rows)
 ----
-====
 
 == Connect to a specific keyspace
 
-Use the `-k` / `--keyspace` option with the `xref:commands:astra-db-cqlsh-start.adoc[]` and `xref:commands:astra-db-cqlsh-exec.adoc[]` commands to connect directly to a specific keyspace:
+Use the `-k` / `--keyspace` option to connect directly to a specific keyspace:
 
+* With `xref:commands:astra-db-cqlsh-start.adoc[]`:
++
 [source,shell,subs="+quotes"]
 ----
 astra db cqlsh start **DB_ID** -k **KEYSPACE_NAME**
 ----
-
++
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 Connected to cndb at 127.0.0.1:9042.
@@ -167,16 +150,15 @@ Connected to cndb at 127.0.0.1:9042.
 Use HELP for help.
 token@cqlsh:my_keyspace>
 ----
-====
 
+* With `xref:commands:astra-db-cqlsh-exec.adoc[]`:
++
 [source,shell,subs="+quotes"]
 ----
 astra db cqlsh exec **DB_ID** -k **KEYSPACE_NAME** "DESC TABLES"
 ----
-
++
 .Result
-[%collapsible]
-====
 [source,console]
 ----
 repairs              view_builds_in_progress  paxos           transferred_ranges
@@ -185,7 +167,6 @@ batches              compaction_history       built_views
 prepared_statements  sstable_activity         range_xfers
 "IndexInfo"          peer_events              local
 ----
-====
 
 ////
 TODO: Consider adding the following sections later:


### PR DESCRIPTION
This PR doesn't modify the autogenerated content.

I rearranged some content to account for the removals. In some cases, I edited some wording slightly for clarity.

* [cqlsh.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/quickstarts/cqlsh.html)
* [install.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/install.html): Moved Homebrew under macOS and Linux (I am assuming it's not available for Windows?)
* [manage-cli.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/manage-cli.html): Mostly just straightforward collapsible removal. Notable sections: [Help](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/manage-cli.html#get-command-help) and [Output Format](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/manage-cli.html#command-output).
* [uninstall.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/uninstall.html)
* [upgrade-pre-1.0.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/upgrade-pre-1.0.html)
* [upgrade.adoc](https://d5rxiv0do0q3v.cloudfront.net/doc-5730/astra-cli/upgrade.html) - combined macOS, Linux, and Windows because the commands were the same except for Windows being run in a PowerShell terminal.

Edited `in-progress` for consistency, even though these aren't published. You can just ignore those changes.