### PR TITLE
DOC-5730 Update RBAC links and terminology

### DIFF
--- a/in-progress/administration.adoc
+++ b/in-progress/administration.adoc
@@ -116,7 +116,7 @@ astra user invite **USER_EMAIL**
 
 [IMPORTANT]
 ====
-If you don't specify a role when inviting a user, the user is automatically assigned the default role of {database-administrator-role}.
+If you don't specify a role when inviting a user, the user is automatically assigned the {database-administrator-role} role.
 ====
 
 === `user invite` options
@@ -391,7 +391,7 @@ OPTIONS
 [#list-roles]
 == List roles
 
-Use the `astra role list` command to list all xref:astra-db-serverless:administration:manage-database-access.adoc#default-roles[default roles] and xref:astra-db-serverless:administration:manage-database-access.adoc#custom-roles[custom roles] in your {product-short} organization:
+Use the `astra role list` command to list all xref:astra-db-serverless:administration:rbac.adoc[built-in and custom roles] in your {product-short} organization:
 
 [source,bash]
 ----


### PR DESCRIPTION
Update links and terminology based on changes made while removing tabs and collapsibles from the Astra docs.

* I am trying to change "default role" to "built-in role" generally. In the main Astra RBAC topics, there are parenthetical references to both terms, but outside of those topics, I am trying to stick to "built-in". Reasoning:
   * There are no references to either "default" or "built-in" in the Portal or DevOps API. This terminology is purely for documentation purposes.
   * Default might imply that users are automatically assigned to those roles. The only auto-assigned roles are 1) Org Admin when you create an account or organization, 2) Enterprise Admin when an enterprise is created on your behalf, or 3) the JIT provisioning role when SSO is enabled (a user is assigned the JIT role if Astra creates an account on their behalf). Of the many built-in roles, only 3 can be auto-assigned.
   * The JIT _default role_ has a different meaning than Astra's built-in ("default") roles. The JIT role is a _default value_ if no other role information is available; this is not the same as _pre-existing role profiles_.
   * Outside of the main Astra RBAC topics, there are few cases where we truly need to differentiate between built-in and custom roles. Typically, we use just _role/roles_, or we listing a few built-in roles followed by _or a custom role with the required permissions_.